### PR TITLE
Create extension in public schema.

### DIFF
--- a/install/amazon_rds/01_configure_rds_instance.md
+++ b/install/amazon_rds/01_configure_rds_instance.md
@@ -57,7 +57,7 @@ Connect to your database as an RDS superuser (usually the credentials you create
 Run the following SQL commands to enable the extension, and make sure it was installed correctly:
 
 ```
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 SELECT * FROM pg_stat_statements LIMIT 1;
 ```
 

--- a/install/amazon_rds/02_create_monitoring_user.md
+++ b/install/amazon_rds/02_create_monitoring_user.md
@@ -11,7 +11,7 @@ Run the following whilst connected as an RDS superuser, replacing `mypassword` w
 ```
 CREATE SCHEMA pganalyze;
 
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 
 CREATE OR REPLACE FUNCTION pganalyze.get_stat_statements(showtext boolean = true) RETURNS SETOF pg_stat_statements AS
 $$


### PR DESCRIPTION
Executing `pganalyze-collector --config=/etc/pganalyze-collector.conf --test` I see this error message:

    [ec2-user@ip-10-112-0-176 ~]$ pganalyze-collector --config=/etc/pganalyze-collector.conf --test
    2018/08/06 16:16:54 I [xxx] Testing statistics collection...
    2018/08/06 16:16:54 I [xxx] pg_stat_statements does not exist, trying to create extension...
    2018/08/06 16:16:54 E [xxx] Error collecting pg_stat_statements
    2018/08/06 16:16:54 E [xxx] Could not process database: pq: relation "public.pg_stat_statements" does not exist

I've installed `pg_stat_statements` extenstion but this extension isn't installed in public schema:

    xxx=> \dx
                                           List of installed extensions
            Name        | Version |     Schema     |                        Description
    --------------------+---------+----------------+-----------------------------------------------------------
     pg_stat_statements | 1.5     | db_init_flyway | track execution statistics of all SQL statements executed
     plpgsql            | 1.0     | pg_catalog     | PL/pgSQL procedural language
    (2 rows)
    
    xxx=>

I was looking for parameter to configure schema, but didn't find it:

https://gist.github.com/lfittl/475cbd3d39a0a79959fb15b2871db73a

Because of all things described above I believe that pganalyze-collector expects that pg_stat_statements extension is installed in `public` schema.

For that reason you need to pass `SCHEMA` parameter into `CREATE EXTENSION` statement.
This PR fixes documentation for that.