### PR TITLE
Improve expensive insight

### DIFF
--- a/explain/insights/expensive.md
+++ b/explain/insights/expensive.md
@@ -7,7 +7,7 @@ backlink_title: 'Documentation: EXPLAIN - Insights'
 
 **Description:**
 
-Postgres will often spend most of its time on a query in a small set of plan nodes. A slow plan  This insight identifies the most expensive nodes to guide optimization. Even if other insights point to different nodes, you should probably focus on the most expensive ones first: there is little to be gained by optimizing an inefficiency unless it is also a bottleneck.
+Postgres will often spend most of its time on a query in a small set of plan nodes. This insight identifies the most expensive nodes to guide optimization. Even if other insights point to different nodes, you should probably focus on the most expensive ones first: there is little to be gained by optimizing an inefficiency unless it is also a bottleneck.
 
 **Recommended Action:**
 

--- a/explain/insights/expensive.md
+++ b/explain/insights/expensive.md
@@ -7,7 +7,7 @@ backlink_title: 'Documentation: EXPLAIN - Insights'
 
 **Description:**
 
-Postgres will often spend most of its time on a query in a small set of plan nodes. This insight identifies the most expensive nodes to guide optimization. Even if other insights point to different nodes, you should probably focus on the most expensive ones first: there is little to be gained by optimizing an inefficiency unless it is also a bottleneck.
+Postgres will often spend most of its time on a query in a small set of plan nodes. This insight identifies the most expensive nodes (according to estimated cost) to guide optimization. Even if other insights point to different nodes, you should probably focus on the most expensive ones first: there is little to be gained by optimizing an inefficiency unless it is also a bottleneck.
 
 **Recommended Action:**
 


### PR DESCRIPTION
See https://github.com/pganalyze/pganalyze/issues/709

Re: the "give more complete example" suggestion--I think we should probably focus on improving this and the other cost-based insights overall first: right now, we always use estimated cost for node cost because that's the only thing we're (almost) guaranteed to always have available. We should probably rethink that and try to use these three in order instead:

 * actual time
 * i/o time
 * estimated cost

If we do that consistently throughout our insights, I think that will make these more useful, and we can then flesh out with examples.