### PR TITLE
Enterprise 2020.07.0 release note improvements

### DIFF
--- a/enterprise/releases/2020-07-0.md
+++ b/enterprise/releases/2020-07-0.md
@@ -30,9 +30,9 @@ backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
 * VACUUM statistics
   - 7 day retention for detailed statistics (increased from 24h)
   - 30 day view of dead tuples for tables (increased from 24h)
-* Server list: Limit to 5 servers in navigation
-  - This avoids issues when having a lot of servers, instead directing to the server overview list
-  - 5 servers shown are those most recently visited
+* Smarter server list in navigation menu
+  - Shows 5 most recently visited servers
+  - This avoids issues when having a lot of servers (which are better viewed on the per-organization server list)
 * Update wait events to include Postgres 12 support
 * Add 7-day trend analysis to table overview
 
@@ -45,7 +45,7 @@ backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
   - Fix visualization bugs for Z00 classification of unknown log lines
   - Connection tracing: Fix connection logs for cases where the `log_line_prefix` is missing %d
 * Internal Enterprise Edition logging
-  - Always output webserver logs to stdout & don't include request_id
+  - Always output webserver logs to stdout, and hide request_id to make logs easier to read
   - Don't run collector in verbose mode
 * Verify `MAILER_URL` setting when doing self-check
 * Default to "localhost" for email application domain instead of "pganalyze.com"
@@ -95,11 +95,6 @@ backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
 * Per-server API keys are no longer created
   - They can still be used for compatibility purposes, going forward the collector utilizes organization API keys for authentication
   - We may deprecate that usage and fully remove per-server API keys in the future, please ensure you use organization API keys when running the collector separately from the main pganalyze container
-* Use `gen_random_uuid()` for all UUID generation
-  - This allows a more streamlined Enterprise setup for situations where the
-    pganalyze user isn't allowed to create extensions (and so they need to
-    be pre-created, which now only "pgcrypto" needs to be for UUIDs), and
-    is aligned with Postgres 13 making `gen_random_uuid()` a built-in function
 * Send cookies with API requests
   - This helps support reverse proxy setups, such as when using Cloudflare
     Access (which requires the special `CF_Authorization` cookie to be passed)


### PR DESCRIPTION
- Improve wording for change with server list in navigation
- Clarify wording for webserver log output change
- Remove note on gen_random_uuid() change - whilst this occurred, we
  haven't removed uuid-ossp from the DB structure yet, so uuid-ossp
  is still required for installation (although its not used)