### PR TITLE
Log Event S6: Fix typo in example SQL queries

### DIFF
--- a/log-insights/server/S6.md
+++ b/log-insights/server/S6.md
@@ -63,7 +63,7 @@ postgres=# SELECT datname FROM pg_database WHERE oid = 16385;
 And then connecting to that database (`mydb` in this case) and running the following, which gives us the affected table or index:
 
 ```
-postgres=# SELECT relname, relkind FROM pg_class WHERE relfilenode = 335458;
+postgres=# SELECT relname, relkind FROM pg_class WHERE relfilenode = 99454;
  relname  | relkind
 --------- +---------
  my_table | r


### PR DESCRIPTION
As reported by someone, the example uses the wrong `relfilenode` in reference to the log message presented. This can be confusing when trying to follow the instructions.