### PR TITLE
Fix Heroku Button refactor

### DIFF
--- a/install/heroku_postgres/01_deploy_the_collector.mdx
+++ b/install/heroku_postgres/01_deploy_the_collector.mdx
@@ -13,7 +13,7 @@ export const APIKey = ({ apiKey }) => !!apiKey ? <> <code>{apiKey}</code></> : n
 export const HerokuButton = ({ apiKey }) => {
   let href = 'https://heroku.com/deploy?template=https://github.com/pganalyze/collector'
   if (apiKey) {
-    href += `&env[PGA_API_KEY]=${props.apiKey}`
+    href += `&env[PGA_API_KEY]=${apiKey}`
   }
   return (
     <p>


### PR DESCRIPTION
The change worked in public docs but fails if there *is* an API key to
reference (e.g., in-app). This fixes the key reference.