### PR TITLE
First stab at documenting install script

### DIFF
--- a/collector/packages.mdx
+++ b/collector/packages.mdx
@@ -1,0 +1,25 @@
+---
+title: 'pganalyze Collector packages'
+backlink_href: /docs/collector
+backlink_title: 'pganalyze Collector'
+---
+
+import CollectorPkgInstallInstructions from '../components/CollectorPkgInstallInstructions'
+
+The collector is available on common Debian-based and Red Hat-based Linux distributions.
+We recommend running our install script to automatically detect your platform and
+install the correct package:
+
+```
+curl https://packages.pganalyze.com/collector-install.sh | bash
+```
+
+Alternately, you can install these packages manually.
+
+<CollectorPkgInstallInstructions />
+
+These repositories are updated by pganalyze whenever a new stable version of the
+collector is released.
+
+You can also build the collector from source: Go 1.16 and `make` are required. To build,
+just run `make`.

--- a/collector/packages.mdx
+++ b/collector/packages.mdx
@@ -6,7 +6,10 @@ backlink_title: 'pganalyze Collector'
 
 import CollectorPkgInstallInstructions from '../components/CollectorPkgInstallInstructions'
 
-The collector is available on common Debian-based and Red Hat-based Linux distributions.
+Pre-built collector packages are available on common Debian-based and Red Hat-based Linux
+distributions for x86-based architectures. Support for BSD-based platforms, or other
+architectures like ARM is available by building [from source](https://github.com/pganalyze/collector).
+
 We recommend running our install script to automatically detect your platform and
 install the correct package:
 
@@ -21,5 +24,5 @@ Alternately, you can install these packages manually.
 These repositories are updated by pganalyze whenever a new stable version of the
 collector is released.
 
-You can also build the collector from source: Go 1.16 and `make` are required. To build,
-just run `make`.
+You can also build the collector [from source](https://github.com/pganalyze/collector): Go 1.16 and
+`make` are required. To build, just run `make`.

--- a/components/CollectorInstallInstructions.tsx
+++ b/components/CollectorInstallInstructions.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { useCodeBlock } from './CodeBlock'
+
+import RepositorySigningKey from './RepositorySigningKey'
+
+type Props = {
+  env?: { [key: string]: string }
+}
+
+const CollectorInstallInstructions: React.FunctionComponent<Props> = ({env}) => {
+  const CodeBlock = useCodeBlock();
+  let bashCmd: string;
+  if (!env || Object.keys(env).length === 0) {
+    bashCmd = 'bash';
+  } else {
+    bashCmd = Object.entries(env).reduce((cmdStr, [ nextKey, nextVal ]) => {
+      return cmdStr + ` ${nextKey}=${nextVal}`
+    }, 'env') + ' bash'
+  }
+  return (
+    <>
+      <p>
+        We recommend running our install script to automatically detect your platform and
+        install the correct package:
+      </p>
+      <CodeBlock>
+        curl https://packages.pganalyze.com/collector-install.sh | {bashCmd}
+      </CodeBlock>
+      <RepositorySigningKey />
+      <p>
+        Alternately, you can follow the <a href="https://pganalyze.com/docs/collector/packages">manual install instructions</a>.
+      </p>
+    </>
+  )
+}
+
+export default CollectorInstallInstructions;

--- a/components/CollectorInstallInstructions.tsx
+++ b/components/CollectorInstallInstructions.tsx
@@ -4,13 +4,28 @@ import { useCodeBlock } from './CodeBlock'
 import RepositorySigningKey from './RepositorySigningKey'
 
 type Props = {
-  env?: { [key: string]: string }
+  apiKey?: string
+  guided?: boolean
 }
 
-const CollectorInstallInstructions: React.FunctionComponent<Props> = ({env}) => {
+const CollectorInstallInstructions: React.FunctionComponent<Props> = ({apiKey, guided}) => {
+  const env = {};
+  if (apiKey) {
+    env['PGA_API_KEY'] = apiKey
+  }
+  if (guided) {
+    env['PGA_API_GUIDED_SETUP'] = 'true'
+  }
+
+  return <CollectorEnvInstallInstructions env={env} />
+}
+
+const CollectorEnvInstallInstructions: React.FunctionComponent<{
+  env: { [key: string]: string }
+}> = ({env}) => {
   const CodeBlock = useCodeBlock();
   let bashCmd: string;
-  if (!env || Object.keys(env).length === 0) {
+  if (Object.keys(env).length === 0) {
     bashCmd = 'bash';
   } else {
     bashCmd = Object.entries(env).reduce((cmdStr, [ nextKey, nextVal ]) => {

--- a/components/CollectorInstallInstructions.tsx
+++ b/components/CollectorInstallInstructions.tsx
@@ -26,7 +26,7 @@ const CollectorInstallInstructions: React.FunctionComponent<Props> = ({env}) => 
       <CodeBlock>
         curl https://packages.pganalyze.com/collector-install.sh | {bashCmd}
       </CodeBlock>
-      <RepositorySigningKey />
+      <RepositorySigningKey small />
       <p>
         Alternately, you can follow the <a href="https://pganalyze.com/docs/collector/packages">manual install instructions</a>.
       </p>

--- a/components/CollectorInstallInstructions.tsx
+++ b/components/CollectorInstallInstructions.tsx
@@ -14,7 +14,7 @@ const CollectorInstallInstructions: React.FunctionComponent<Props> = ({apiKey, g
     env['PGA_API_KEY'] = apiKey
   }
   if (guided) {
-    env['PGA_API_GUIDED_SETUP'] = 'true'
+    env['PGA_GUIDED_SETUP'] = 'true'
   }
 
   return <CollectorEnvInstallInstructions env={env} />

--- a/components/CollectorPkgInstallInstructions.tsx
+++ b/components/CollectorPkgInstallInstructions.tsx
@@ -1,8 +1,40 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import TabPanel, { TabItem } from './TabPanel'
 import { useCodeBlock } from './CodeBlock'
 import RepositorySigningKey from './RepositorySigningKey'
+
+const CollectorPkgInstallInstructions = () => {
+  const [ pkgKind, setPkgKind ] = useState('yum')
+  const handleDistroChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPkgKind(e.currentTarget.value)
+  }
+  return (
+    <>
+      <p>
+        Choose which OS distribution you are running:
+      </p>
+      <div style={{paddingLeft: '16px', paddingBottom: '8px'}}>
+        <label style={{display: 'block', fontWeight: 'normal'}}>
+          <input style={{marginRight: '4px'}} type='radio' name='distro' value='yum' onChange={handleDistroChange} checked={pkgKind === 'yum'} />
+          RPM based (RHEL, Amazon Linux, Fedora, CentOS)
+        </label>
+        <label style={{display: 'block', fontWeight: 'normal'}}>
+          <input style={{marginRight: '4px'}} type='radio' name='distro' value='deb' onChange={handleDistroChange} checked={pkgKind === 'deb'} />
+          Debian based (Debian, Ubuntu)
+        </label>
+      </div>
+      <p>
+        SSH into your system and run the following to download and install the package:
+      </p>
+      {pkgKind === 'deb' ? (
+        <CollectorDistroInstallInstructions kind='deb' />
+      ) : pkgKind === 'yum' ? (
+        <CollectorDistroInstallInstructions kind='yum' />
+      ) : null}
+    </>
+  )
+}
 
 type YumProps = {
   kind: 'yum'
@@ -16,7 +48,7 @@ type DebProps = {
 
 type Props = YumProps | DebProps
 
-const CollectorPkgInstallInstructions: React.FunctionComponent<Props> = ({ kind }) => {
+const CollectorDistroInstallInstructions: React.FunctionComponent<Pick<Props, 'kind'>> = ({ kind }) => {
   type InstallOpt = [id: string, distro: YumProps['distro'] | DebProps['distro'], label: string];
   let installOpts: InstallOpt[] = [];
   switch (kind) {

--- a/components/RepositorySigningKey.tsx
+++ b/components/RepositorySigningKey.tsx
@@ -3,11 +3,35 @@ import { useIcon } from './WithIcons';
 
 import styles from './style.module.scss';
 
-const RepositorySigningKey: React.FunctionComponent = () => {
-  const SecureIcon = useIcon('secure');
-  const keyUrl = 'https://packages.pganalyze.com/pganalyze_signing_key.asc';
+type Props = {
+  small?: boolean
+}
+
+const KEY_URL = 'https://packages.pganalyze.com/pganalyze_signing_key.asc';
+
+const RepositorySigningKey: React.FunctionComponent<Props> = ({small}) => {
   return (
     <div style={{fontSize: '14px', padding: '6px 16px 4px', borderTop: '1px solid gray', borderBottom: '1px solid gray', marginBottom: '16px'}}>
+      {small ? <SmallKey /> : <Key />}
+    </div>
+  )
+}
+
+const SmallKey: React.FunctionComponent = () => {
+  const SecureIcon = useIcon('secure');
+  return (
+    <div>
+      <strong>
+        <SecureIcon className={styles.secureIcon} />Repository Signing Key Fingerprint
+      </strong>: C09B 2CAB 0DB3 78F6 E7FD 93F1 0E6D EC71 A2B5 F2F9
+    </div>
+  )
+}
+
+const Key: React.FunctionComponent = () => {
+  const SecureIcon = useIcon('secure');
+  return (
+    <>
       <div>
         <strong>
           <SecureIcon className={styles.secureIcon} />Repository Signing Key
@@ -17,9 +41,9 @@ const RepositorySigningKey: React.FunctionComponent = () => {
         <strong>Fingerprint</strong>: C09B 2CAB 0DB3 78F6 E7FD 93F1 0E6D EC71 A2B5 F2F9 
       </div>
       <div>
-        <strong>Download</strong>: <a href={keyUrl}>{keyUrl}</a>
+        <strong>Download</strong>: <a href={KEY_URL}>{KEY_URL}</a>
       </div>
-    </div>
+    </>
   )
 }
 

--- a/directory.json
+++ b/directory.json
@@ -36,6 +36,10 @@
       "title": "pganalyze Collector",
       "path": "/docs/collector"
     },
+    "collector/packages": {
+      "title": "pganalyze Collector packages",
+      "path": "/docs/collector/packages"
+    },
     "collector/settings": {
       "title": "pganalyze Collector settings",
       "path": "/docs/collector/settings"

--- a/install/amazon_rds/04_install_collector_ec2.mdx
+++ b/install/amazon_rds/04_install_collector_ec2.mdx
@@ -5,44 +5,9 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
-import { useState } from 'react'
+import CollectorInstallInstructions from "../../components/CollectorInstallInstructions"
 
 import imgRdsNewInstanceRole from "../../images/rds_new_instance_role.png"
-
-import CollectorPkgInstallInstructions from "../../components/CollectorPkgInstallInstructions"
-import RepositorySigningKey from "../../components/RepositorySigningKey"
-
-export const CollectorInstallInstructions = () => {
-  const [ pkgKind, setPkgKind ] = useState('yum')
-  const handleDistroChange = (e) => {
-    setPkgKind(e.currentTarget.value)
-  }
-  return (
-    <>
-      <p>
-        Choose which OS distribution you are running on your EC2 instance:
-      </p>
-      <div style={{paddingLeft: '16px', paddingBottom: '8px'}}>
-        <label style={{display: 'block', fontWeight: 'normal'}}>
-          <input style={{marginRight: '4px'}} type='radio' name='distro' value='yum' onChange={handleDistroChange} checked={pkgKind === 'yum'} />
-          RPM based (RHEL, Amazon Linux, Fedora, CentOS)
-        </label>
-        <label style={{display: 'block', fontWeight: 'normal'}}>
-          <input style={{marginRight: '4px'}} type='radio' name='distro' value='deb' onChange={handleDistroChange} checked={pkgKind === 'deb'} />
-          Debian based (Debian, Ubuntu)
-        </label>
-      </div>
-      <p>
-        SSH into your EC2 instance and, run the following to download and install the package:
-      </p>
-      {pkgKind === 'deb' ? (
-        <CollectorPkgInstallInstructions kind='deb' />
-      ) : pkgKind === 'yum' ? (
-        <CollectorPkgInstallInstructions kind='yum' />
-      ) : null}
-    </>
-  )
-}
 
 ## Installing the collector on an Amazon EC2 Instance
 

--- a/install/amazon_rds/04_install_collector_ec2.mdx
+++ b/install/amazon_rds/04_install_collector_ec2.mdx
@@ -30,7 +30,7 @@ Then follow the step to install the collector on Amazon Linux 2 based instances.
 
 ## Installing the collector on the instance
 
-<CollectorInstallInstructions />
+<CollectorInstallInstructions apiKey={props.apiKey} />
 
 After successful installation the pganalyze collector will now be running in the background on your server.
 

--- a/install/azure_database/02_install_the_collector_deb.mdx
+++ b/install/azure_database/02_install_the_collector_deb.mdx
@@ -5,22 +5,11 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
-import CollectorPkgInstallInstructions from "../../components/CollectorPkgInstallInstructions"
+import CollectorInstallInstructions from "../../components/CollectorInstallInstructions"
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-First, you need to know which version of Ubuntu/Debian you are running. You can find out with this command:
-
-```
-lsb_release -a
-```
-
-Now run the appropriate commands for your version:
-
-<CollectorPkgInstallInstructions kind='deb' />
-
-These repositories are updated by pganalyze whenever a new stable version of the
-collector is released.
+<CollectorInstallInstructions />
 
 <Link className="btn btn-success" to="03_configure_the_collector_package">
   Continue to Step 3: Configure the Collector

--- a/install/azure_database/02_install_the_collector_deb.mdx
+++ b/install/azure_database/02_install_the_collector_deb.mdx
@@ -9,7 +9,7 @@ import CollectorInstallInstructions from "../../components/CollectorInstallInstr
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-<CollectorInstallInstructions />
+<CollectorInstallInstructions apiKey={props.apiKey} />
 
 <Link className="btn btn-success" to="03_configure_the_collector_package">
   Continue to Step 3: Configure the Collector

--- a/install/azure_database/02_install_the_collector_yum.mdx
+++ b/install/azure_database/02_install_the_collector_yum.mdx
@@ -5,21 +5,11 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
-import CollectorPkgInstallInstructions from "../../components/CollectorPkgInstallInstructions"
+import CollectorInstallInstructions from "../../components/CollectorInstallInstructions"
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-First, you need to know which version of RHEL/CentOS/Fedora you are running. You can find out with this command:
-
-```
-cat /etc/system-release
-```
-
-Now run the appropriate commands for your version:
-
-<CollectorPkgInstallInstructions kind='yum' />
-
-These repositories are updated by pganalyze whenever a new stable version of the collector is released.
+<CollectorInstallInstructions />
 
 <Link className="btn btn-success" to="03_configure_the_collector_package">
   Continue to Step 3: Configure the Collector

--- a/install/azure_database/02_install_the_collector_yum.mdx
+++ b/install/azure_database/02_install_the_collector_yum.mdx
@@ -9,7 +9,7 @@ import CollectorInstallInstructions from "../../components/CollectorInstallInstr
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-<CollectorInstallInstructions />
+<CollectorInstallInstructions apiKey={props.apiKey} />
 
 <Link className="btn btn-success" to="03_configure_the_collector_package">
   Continue to Step 3: Configure the Collector

--- a/install/google_cloud_sql/02_install_the_collector_deb.mdx
+++ b/install/google_cloud_sql/02_install_the_collector_deb.mdx
@@ -9,7 +9,7 @@ import CollectorInstallInstructions from '../../components/CollectorInstallInstr
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-<CollectorInstallInstructions />
+<CollectorInstallInstructions apiKey={props.apiKey} />
 
 <Link className="btn btn-success" to="03_configure_the_collector_package">
   Continue to Step 3: Configure the Collector

--- a/install/google_cloud_sql/02_install_the_collector_deb.mdx
+++ b/install/google_cloud_sql/02_install_the_collector_deb.mdx
@@ -5,22 +5,11 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
-import CollectorPkgInstallInstructions from '../../components/CollectorPkgInstallInstructions'
+import CollectorInstallInstructions from '../../components/CollectorInstallInstructions'
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-First, you need to know which version of Ubuntu/Debian you are running. You can find out with this command:
-
-```
-lsb_release -a
-```
-
-Now run the appropriate commands for your version:
-
-<CollectorPkgInstallInstructions kind="deb" />
-
-These repositories are updated by pganalyze whenever a new stable version of the
-collector is released.
+<CollectorInstallInstructions />
 
 <Link className="btn btn-success" to="03_configure_the_collector_package">
   Continue to Step 3: Configure the Collector

--- a/install/google_cloud_sql/02_install_the_collector_yum.mdx
+++ b/install/google_cloud_sql/02_install_the_collector_yum.mdx
@@ -5,21 +5,11 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
-import CollectorPkgInstallInstructions from '../../components/CollectorPkgInstallInstructions'
+import CollectorInstallInstructions from '../../components/CollectorInstallInstructions'
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-First, you need to know which version of RHEL/CentOS/Fedora you are running. You can find out with this command:
-
-```
-cat /etc/system-release
-```
-
-Now run the appropriate commands for your version:
-
-<CollectorPkgInstallInstructions kind='yum' />
-
-These repositories are updated by pganalyze whenever a new stable version of the collector is released.
+<CollectorInstallInstructions />
 
 <Link className="btn btn-success" to="03_configure_the_collector_package">
   Continue to Step 3: Configure the Collector

--- a/install/google_cloud_sql/02_install_the_collector_yum.mdx
+++ b/install/google_cloud_sql/02_install_the_collector_yum.mdx
@@ -9,7 +9,7 @@ import CollectorInstallInstructions from '../../components/CollectorInstallInstr
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-<CollectorInstallInstructions />
+<CollectorInstallInstructions apiKey={props.apiKey} />
 
 <Link className="btn btn-success" to="03_configure_the_collector_package">
   Continue to Step 3: Configure the Collector

--- a/install/self_managed/01_guided_setup.mdx
+++ b/install/self_managed/01_guided_setup.mdx
@@ -5,44 +5,27 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
-import CollectorPkgInstallInstructions from '../../components/CollectorPkgInstallInstructions'
+import CollectorInstallInstructions from '../../components/CollectorInstallInstructions'
 
 export const GuidedSetupInvocationExample = ({ apiKey }) => {
+  const installEnv = { PGA_GUIDED_SETUP: 'true' }
+  if (!!apiKey) {
+    installEnv['PGA_API_KEY'] = apiKey
+  }
   return (
-    <CodeBlock>sudo pganalyze-collector-setup{apiKey && ` --api-key=${apiKey}`}</CodeBlock>
+    <CollectorInstallInstructions env={installEnv} />
   );
 };
 
 To begin guided setup, you'll need to install the collector, which sends statistics information
 and query activity to pganalyze.
 
-First, you need to know which version of Ubuntu/Debian you are running. You can find out with this command:
-
-```
-lsb_release -a
-```
-
 Note that guided setup is supported for Ubuntu 14.04 or newer or Debian 10 or newer. If you are
 running an older version, please follow the manual setup instructions.
 
-If your OS distribution is supported, run the appropriate commands for your version:
-
-<CollectorPkgInstallInstructions kind='deb' />
-
-These repositories are updated by pganalyze whenever a new stable version of the
-collector is released.
-
-Now check to ensure the installed collector version supports guided setup:
-
-```
-pganalyze-collector --version
-```
-
-Guided setup is supported starting in version 0.36.
-
 You will need an API key for the install. <PublicOnly>It can be found in the pganalyze Settings page for your organization.</PublicOnly><InAppOnly>It is included in the command below.</InAppOnly>
 
-You'll need to run guided setup as root or using sudo:
+To install the collector and start guided setup, run the following command:
 
 <GuidedSetupInvocationExample apiKey={props.apiKey} />
 

--- a/install/self_managed/01_guided_setup.mdx
+++ b/install/self_managed/01_guided_setup.mdx
@@ -7,16 +7,6 @@ backlink_title: 'Installation Guide'
 
 import CollectorInstallInstructions from '../../components/CollectorInstallInstructions'
 
-export const GuidedSetupInvocationExample = ({ apiKey }) => {
-  const installEnv = { PGA_GUIDED_SETUP: 'true' }
-  if (!!apiKey) {
-    installEnv['PGA_API_KEY'] = apiKey
-  }
-  return (
-    <CollectorInstallInstructions env={installEnv} />
-  );
-};
-
 To begin guided setup, you'll need to install the collector, which sends statistics information
 and query activity to pganalyze.
 
@@ -27,7 +17,7 @@ You will need an API key for the install. <PublicOnly>It can be found in the pga
 
 To install the collector and start guided setup, run the following command:
 
-<GuidedSetupInvocationExample apiKey={props.apiKey} />
+<CollectorInstallInstructions apiKey={props.apiKey} guided />
 
 You'll be shown additional instructions, and prompted to confirm any changes to your system.
 <PublicOnly>

--- a/install/self_managed/03_install_the_collector_deb.mdx
+++ b/install/self_managed/03_install_the_collector_deb.mdx
@@ -5,22 +5,11 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
-import CollectorPkgInstallInstructions from '../../components/CollectorPkgInstallInstructions'
+import CollectorInstallInstructions from '../../components/CollectorInstallInstructions'
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-First, you need to know which version of Ubuntu/Debian you are running. You can find out with this command:
-
-```
-lsb_release -a
-```
-
-Now run the appropriate commands for your version:
-
-<CollectorPkgInstallInstructions kind='deb' />
-
-These repositories are updated by pganalyze whenever a new stable version of the
-collector is released.
+<CollectorInstallInstructions />
 
 <Link className="btn btn-success" to="04_configure_the_collector_package">
   Continue to Step 4: Configure the Collector

--- a/install/self_managed/03_install_the_collector_deb.mdx
+++ b/install/self_managed/03_install_the_collector_deb.mdx
@@ -9,7 +9,7 @@ import CollectorInstallInstructions from '../../components/CollectorInstallInstr
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-<CollectorInstallInstructions />
+<CollectorInstallInstructions apiKey={props.apiKey} />
 
 <Link className="btn btn-success" to="04_configure_the_collector_package">
   Continue to Step 4: Configure the Collector

--- a/install/self_managed/03_install_the_collector_yum.mdx
+++ b/install/self_managed/03_install_the_collector_yum.mdx
@@ -5,21 +5,11 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
-import CollectorPkgInstallInstructions from '../../components/CollectorPkgInstallInstructions'
+import CollectorInstallInstructions from '../../components/CollectorInstallInstructions'
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-First, you need to know which version of RHEL/CentOS/Fedora you are running. You can find out with this command:
-
-```
-cat /etc/system-release
-```
-
-Now run the appropriate commands for your version:
-
-<CollectorPkgInstallInstructions kind='yum' />
-
-These repositories are updated by pganalyze whenever a new stable version of the collector is released.
+<CollectorInstallInstructions />
 
 <Link className="btn btn-success" to="04_configure_the_collector_package">
   Continue to Step 4: Configure the Collector

--- a/install/self_managed/03_install_the_collector_yum.mdx
+++ b/install/self_managed/03_install_the_collector_yum.mdx
@@ -9,7 +9,7 @@ import CollectorInstallInstructions from '../../components/CollectorInstallInstr
 
 In this step we'll install the collector which sends statistics information to pganalyze.
 
-<CollectorInstallInstructions />
+<CollectorInstallInstructions apiKey={props.apiKey} />
 
 <Link className="btn btn-success" to="04_configure_the_collector_package">
   Continue to Step 4: Configure the Collector


### PR DESCRIPTION
This changes our documentation to use the new install script wherever
possible, moves the "manual" package install instructions to a
separate page only in the public docs and links to that page wherever
we reference the script.

Needs testing in-app and we may also want to collapse the
distro-specific collector install pages since many are now identical.

Made the change I had proposed below, so only the manual instructions
include full key information. Other pages just show the fingerprint:

![image](https://user-images.githubusercontent.com/159100/110362016-9ba61500-7ff5-11eb-8dad-506078143b33.png)

---
May also want to avoid linking the key download key on the script pages,
since it may give users the idea that downloading the key is a part of
the install process:

![image](https://user-images.githubusercontent.com/159100/110192364-6b3a5d00-7de2-11eb-864a-d480c0c12c3e.png)

Maybe we should just include the fingerprint here and the download only
on the new collector packages page?