### PR TITLE
Recommend guided setup for broader usage

### DIFF
--- a/install/self_managed/00_choose_setup_method.mdx
+++ b/install/self_managed/00_choose_setup_method.mdx
@@ -13,9 +13,8 @@ ways of doing this:
  * **guided setup**: run a setup program which will prompt you for input and confirmation
 and make necessary changes on your behalf
 
-The guided setup program is in a pilot stage and we do not recommend using it on production
-systems yet. However, it's a simpler way to get started on development sytems, and can
-also set up [Automated EXPLAIN](https://pganalyze.com/postgres-explain) and
+The guided setup program is a simpler way to get started on supported systems, and can also
+set up [Automated EXPLAIN](https://pganalyze.com/postgres-explain) and
 [Log Insights](https://pganalyze.com/log-insights) for you.
 
 We recommend trying the guided setup program if your system **meets the following criteria**:
@@ -23,7 +22,6 @@ We recommend trying the guided setup program if your system **meets the followin
  * Ubuntu 14.04 or newer, or Debian 10 or newer
  * Postgres 10 or newer
  * Collector installed on the same system as your Postgres server
- * Not a production system
 
 Otherwise, you'll need to follow the manual setup instructions. We plan to expand the
 configurations supported for guided setup soon.


### PR DESCRIPTION
Remove the suggestion to avoid using guided setup on production
systems to encourage broader adoption.
