### PR TITLE
Drop tableNames from GraphQL getQueryStats documentation

### DIFF
--- a/api/queries/getQueryStats.mdx
+++ b/api/queries/getQueryStats.mdx
@@ -27,7 +27,6 @@ Fields returned:
 * **`truncatedQuery` (string)**<br/>Shortened query text up to 100 characters (same as displayed in "Query Performance" overview)
 * **`queryComment` (string)**<br/>First comment contained in the query (this is taken from the full query string, not just the truncated one)
 * **`statementType` (array of strings)**<br/>List of statement type(s) used in this query
-* **`tableNames` (array of strings)**<br/>Fully qualified list of table names used in this query
 * **`totalCalls` (integer)**<br/>Total number of calls for this query
 * **`avgTime` (float)**<br/>Average runtime in milliseconds for this query
 * **`avgIoTime` (float)**<br/>Average time spent in I/O operations for this query (this requires `track_io_timing` to be enabled on the database)
@@ -45,7 +44,6 @@ query {
     queryUrl
     truncatedQuery
     statementType
-    tableNames
     totalCalls
     avgTime
     bufferHitRatio
@@ -55,7 +53,7 @@ query {
 ```
 
 ```
-curl -XPOST -H 'Authorization: Token XXXXXXX' -F 'query=query { getQueryStats(databaseId: 12345) { id, queryUrl, truncatedQuery, statementType, tableNames, totalCalls, avgTime, bufferHitRatio, pctOfTotal } }' https://app.pganalyze.com/graphql
+curl -XPOST -H 'Authorization: Token XXXXXXX' -F 'query=query { getQueryStats(databaseId: 12345) { id, queryUrl, truncatedQuery, statementType, totalCalls, avgTime, bufferHitRatio, pctOfTotal } }' https://app.pganalyze.com/graphql
 ```
 
 ```
@@ -68,9 +66,6 @@ curl -XPOST -H 'Authorization: Token XXXXXXX' -F 'query=query { getQueryStats(da
         "truncatedQuery": "UPDATE \"pgbench_accounts\" SET abalance = $1 WHERE \"aid\" = $2",
         "statementType": [
           "UPDATE"
-        ],
-        "tableNames": [
-          "pgbench_accounts"
         ],
         "totalCalls": 1887313,
         "avgTime": 35.3024511808419,
@@ -103,7 +98,6 @@ query {
     queryUrl
     truncatedQuery
     statementType
-    tableNames
     totalCalls
     avgTime
     bufferHitRatio
@@ -134,7 +128,7 @@ puts csv_output
 This will output the following on stdout:
 
 ```
-id,queryUrl,truncatedQuery,statementType,tableNames,totalCalls,avgTime,bufferHitRatio,pctOfTotal
+id,queryUrl,truncatedQuery,statementType,totalCalls,avgTime,bufferHitRatio,pctOfTotal
 678910,https://app.pganalyze.com/databases/12345/queries/678910,"UPDATE ""pgbench_accounts"" SET abalance = $1 WHERE ""aid"" = $2","[""UPDATE""]","[""pgbench_accounts""]",1887313,35.3024511808419,69.50736528891339,96.0880225982751
 ...
 ```


### PR DESCRIPTION
This field causes an n+1 query which is too slow to be useful in most
situations. We should optimize, but for now, just drop the field from
the documentation.
