### PR TITLE
Update docs to create pganalyze schema if necessary for log-based EXPLAIN

### DIFF
--- a/explain/setup/log_explain/01_create_helper_functions.mdx
+++ b/explain/setup/log_explain/01_create_helper_functions.mdx
@@ -18,6 +18,7 @@ In order to use log-based EXPLAIN, the collector needs permissions to run EXPLAI
 The safest way to permit this is to create the following helper function **in each database you want to monitor**:
 
 ```sql
+CREATE SCHEMA IF NOT EXISTS pganalyze;
 CREATE OR REPLACE FUNCTION pganalyze.explain(query text, params text[]) RETURNS text AS
 $$
 DECLARE


### PR DESCRIPTION
This only happens right now with Heroku Postgres, where we do not
create a separate monitoring user. We've gotten two support tickets
recently asking about the missing schema.

Given that the log-based EXPLAIN docs are generic and not specific to
any provider, we can't easily provide Heroku-specific instructions
here without restructuring the install process (which is probably not
worth it anyway for such a small change). However, IF NOT EXISTS
prevents problems on other platforms and is available back to 9.3.
