### PR TITLE
Make docs compatible with MDX 2

### DIFF
--- a/explain/setup/amazon_rds/_01_in_app.mdx
+++ b/explain/setup/amazon_rds/_01_in_app.mdx
@@ -2,20 +2,20 @@ import AutoExplainNotice from '../_auto_explain_notice.mdx'
 
 export const AutoExplainEnabled = () => {
   return (
-    <>
+    <React.Fragment>
       <p>
         It looks like <code>auto_explain</code> is already enabled on this server.
       </p>
       <Link className="btn btn-success" to="03_review_settings">
         Skip to Step 3: Review auto_explain settings
       </Link>
-    </>
+    </React.Fragment>
   )
 }
 
 export const AutoExplainNotEnabled = () => {
   return (
-    <>
+    <React.Fragment>
       <p>
         It looks like <code>auto_explain</code> is not enabled on this server.
       </p>
@@ -23,7 +23,7 @@ export const AutoExplainNotEnabled = () => {
       <Link className="btn btn-success" to="02_enable_auto_explain">
         Proceed to Step 2: Enable auto_explain
       </Link>
-    </>
+    </React.Fragment>
   )
 }
 

--- a/explain/setup/amazon_rds/_02_actually_enable.mdx
+++ b/explain/setup/amazon_rds/_02_actually_enable.mdx
@@ -12,13 +12,13 @@ export const SPLRecommendation = ({recommendation}) => {
       )
    }
    return (
-      <>
+      <React.Fragment>
          <p>
             The current value appears to be <code>{recommendation.current}</code>.
             You can confirm this in the parameter group and set the new value to
             <code>{recommendation.recommended}</code>.
          </p>
-      </>
+      </React.Fragment>
    )
 }
 

--- a/explain/setup/self_managed/_01_in_app.mdx
+++ b/explain/setup/self_managed/_01_in_app.mdx
@@ -2,20 +2,20 @@ import AutoExplainNotice from '../_auto_explain_notice.mdx'
 
 export const AutoExplainEnabled = () => {
   return (
-    <>
+    <React.Fragment>
       <p>
         It looks like <code>auto_explain</code> is already enabled on this server.
       </p>
       <Link className="btn btn-success" to="03_review_settings">
         Skip to Step 3: Review auto_explain settings
       </Link>
-    </>
+    </React.Fragment>
   )
 }
 
 export const AutoExplainNotEnabled = () => {
   return (
-    <>
+    <React.Fragment>
       <p>
         It looks like <code>auto_explain</code> is not enabled on this server.
       </p>
@@ -23,7 +23,7 @@ export const AutoExplainNotEnabled = () => {
       <Link className="btn btn-success" to="02_enable_auto_explain">
         Proceed to Step 2: Enable auto_explain
       </Link>
-    </>
+    </React.Fragment>
   )
 }
 

--- a/explain/setup/self_managed/_02_actually_enable.mdx
+++ b/explain/setup/self_managed/_02_actually_enable.mdx
@@ -1,7 +1,7 @@
 export const SPLRecommendation = ({recommendation}) => {
    if (recommendation.current == null) {
       return (
-         <>
+         <React.Fragment>
             <p>
                For example, if the current value is <code>pg_stat_statements</code>,
                you can set the new value to <code>pg_stat_statements, auto_explain</code>:
@@ -9,11 +9,11 @@ export const SPLRecommendation = ({recommendation}) => {
             <CodeBlock>
                ALTER SYSTEM SET shared_preload_libraries TO pg_stat_statements, auto_explain;
             </CodeBlock>
-         </>
+         </React.Fragment>
       )
    }
    return (
-      <>
+      <React.Fragment>
          <p>
             The current value appears to be <code>{recommendation.current}</code>.
             You can confirm this by running
@@ -27,7 +27,7 @@ export const SPLRecommendation = ({recommendation}) => {
          <CodeBlock>
             ALTER SYSTEM SET shared_preload_libraries TO {recommendation.recommended};
          </CodeBlock>
-      </>
+      </React.Fragment>
    )
 }
 

--- a/install.mdx
+++ b/install.mdx
@@ -49,7 +49,7 @@ To continue please select in which environment you are running your Postgres dat
     className={styles.installChoiceStep}
     to="install/self_managed/00_choose_setup_method"
   >
-    <img src={imgLogoPgsql} />
+    <img style={{width: "16px", height: "21px"}} src={imgLogoPgsql} />
     Self-Managed
     <br />
     <small style={{ marginTop: "-5px", fontSize: "12px" }}>

--- a/install/amazon_rds/05_configure_the_collector_docker.mdx
+++ b/install/amazon_rds/05_configure_the_collector_docker.mdx
@@ -9,7 +9,7 @@ import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_lin
 
 export const CollectorDotEnv = ({ apiKey }) => {
   return (
-    <>
+    <React.Fragment>
       <CodeBlock>
         {`PGA_API_KEY=${apiKey || "your-organization-api-key"}
 DB_HOST=your_database_host
@@ -22,17 +22,17 @@ DB_PASSWORD=your_monitoring_user_password`}
         correct settings for your RDS instance.
         <br />
         {apiKey ? (
-          <>
+          <React.Fragment>
             <code>{apiKey}</code> is your pganalyze API key.
-          </>
+          </React.Fragment>
         ) : (
-          <>
+          <React.Fragment>
             You can find your <code>PGA_API_KEY</code> on your
             organization&apos;s API keys page.
-          </>
+          </React.Fragment>
         )}
       </p>
-    </>
+    </React.Fragment>
   );
 };
 

--- a/install/amazon_rds/05_configure_the_collector_ec2.mdx
+++ b/install/amazon_rds/05_configure_the_collector_ec2.mdx
@@ -9,15 +9,15 @@ import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_lin
 
 export const APIKeyInstructions = ({ apiKey }) => {
   return apiKey ? (
-    <>
+    <React.Fragment>
       The <code>api_key</code> for the current organization is{" "}
       <code>{apiKey}</code>
-    </>
+    </React.Fragment>
   ) : (
-    <>
+    <React.Fragment>
       The <code>api_key</code> can be found in the pganalyze API keys page for
       your organization
-    </>
+    </React.Fragment>
   );
 };
 

--- a/install/amazon_rds/05_configure_the_collector_ecs.mdx
+++ b/install/amazon_rds/05_configure_the_collector_ecs.mdx
@@ -7,17 +7,20 @@ backlink_title: 'Installation Guide'
 
 import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_link.mdx'
 
-export const InviteLink = ({ inviteLink, children }) => {
+export const FinishSetup = ({ inviteLink }) => {
   return (
-    <Link className="btn btn-success" to={inviteLink}>
-      {children}
-    </Link>
-  );
-};
+    <div>
+      In the meantime you can invite your colleagues:
+      <Link className="btn btn-success" to={inviteLink}>
+        Finish setup and invite team members
+      </Link>
+    </div>
+  )
+}
 
 export const SSMConfig = ({ apiKey }) => {
   return (
-    <>
+    <React.Fragment>
       <CodeBlock>
         {`aws ssm put-parameter --name /pganalyze/DB_PASSWORD --type SecureString --value "YOUR_MONITORING_USER_PASSWORD"
 aws ssm put-parameter --name /pganalyze/PGA_API_KEY --type SecureString --value "${
@@ -26,21 +29,21 @@ aws ssm put-parameter --name /pganalyze/PGA_API_KEY --type SecureString --value 
       </CodeBlock>
       <p>
         {apiKey ? (
-          <>
+          <React.Fragment>
             Replace <code>YOUR_DB_PASSWORD</code> with the monitoring user
             password for your database. <code>{apiKey}</code> is your
             organization's API key.
-          </>
+          </React.Fragment>
         ) : (
-          <>
+          <React.Fragment>
             Replace <code>YOUR_PGANALYZE_API_KEY</code> with the API key from
             your organization&apos;s API keys page, and{" "}
             <code>YOUR_DB_PASSWORD</code> with the monitoring user password for
             your database.
-          </>
+          </React.Fragment>
         )}
       </p>
-    </>
+    </React.Fragment>
   );
 };
 
@@ -140,11 +143,7 @@ configured the collector correctly.
 **Your setup is complete. The dashboard will start showing data within 15 minutes.**
 
 <InAppOnly>
-  In the meantime you can invite your colleagues:
-
-  <InviteLink inviteLink={props.inviteLink}>
-    Finish setup and invite team members
-  </InviteLink>
+  <FinishSetup inviteLink={props.inviteLink} />
 </InAppOnly>
 
 <PublicLastStepLogInsightsLink />

--- a/install/azure_database/03_configure_the_collector_docker.mdx
+++ b/install/azure_database/03_configure_the_collector_docker.mdx
@@ -9,15 +9,15 @@ import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_lin
 
 export const APIKeyInstructions = ({ apiKey }) => {
   return apiKey ? (
-    <>
+    <React.Fragment>
       The <code>PGA_API_KEY</code> for the current organization is{" "}
       <code>{apiKey}</code>
-    </>
+    </React.Fragment>
   ) : (
-    <>
+    <React.Fragment>
       The <code>PGA_API_KEY</code> can be found in the pganalyze API keys page
       for your organization
-    </>
+    </React.Fragment>
   );
 };
 

--- a/install/azure_database/03_configure_the_collector_package.mdx
+++ b/install/azure_database/03_configure_the_collector_package.mdx
@@ -9,15 +9,15 @@ import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_lin
 
 export const APIKeyInstructions = ({ apiKey }) => {
   return apiKey ? (
-    <>
+    <React.Fragment>
       The <code>api_key</code> for the current organization is{" "}
       <code>{apiKey}</code>
-    </>
+    </React.Fragment>
   ) : (
-    <>
+    <React.Fragment>
       The <code>api_key</code> can be found in the pganalyze API keys page for
       your organization
-    </>
+    </React.Fragment>
   );
 };
 

--- a/install/google_cloud_sql/03_configure_the_collector_docker.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector_docker.mdx
@@ -9,15 +9,15 @@ import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_lin
 
 export const APIKeyInstructions = ({ apiKey }) => {
   return apiKey ? (
-    <>
+    <React.Fragment>
       The <code>PGA_API_KEY</code> for the current organization is{" "}
       <code>{apiKey}</code>
-    </>
+    </React.Fragment>
   ) : (
-    <>
+    <React.Fragment>
       The <code>PGA_API_KEY</code> can be found in the pganalyze API keys page
       for your organization
-    </>
+    </React.Fragment>
   );
 };
 

--- a/install/google_cloud_sql/03_configure_the_collector_package.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector_package.mdx
@@ -9,15 +9,15 @@ import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_lin
 
 export const APIKeyInstructions = ({ apiKey }) => {
   return apiKey ? (
-    <>
+    <React.Fragment>
       The <code>api_key</code> for the current organization is{" "}
       <code>{apiKey}</code>
-    </>
+    </React.Fragment>
   ) : (
-    <>
+    <React.Fragment>
       The <code>api_key</code> can be found in the pganalyze API keys page for
       your organization
-    </>
+    </React.Fragment>
   );
 };
 

--- a/install/heroku_postgres/01_deploy_the_collector.mdx
+++ b/install/heroku_postgres/01_deploy_the_collector.mdx
@@ -8,7 +8,7 @@ backlink_title: 'Installation Guide'
 import imgHerokuPaidDyno from "../../images/heroku_paid_dyno.png"
 import { collectorAppName } from "./util";
 
-export const APIKey = ({ apiKey }) => !!apiKey ? <> <code>{apiKey}</code></> : null;
+export const APIKey = ({ apiKey }) => !!apiKey ? <React.Fragment> <code>{apiKey}</code></React.Fragment> : null;
 
 export const HerokuButton = ({ apiKey }) => {
   let href = 'https://heroku.com/deploy?template=https://github.com/pganalyze/collector'

--- a/install/self_managed/00_choose_setup_method.mdx
+++ b/install/self_managed/00_choose_setup_method.mdx
@@ -5,6 +5,22 @@ backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
 
+export const SetupOptions = () => {
+  return (
+    <div>
+      <Link className="btn btn-success" to="01_guided_setup">
+        Continue with guided setup
+      </Link>
+      <span style={{fontSize: '14px', marginLeft: '6px'}}>
+        <span> or proceed with </span>
+        <Link to="01_create_monitoring_user">
+          manual setup
+        </Link>
+      </span>
+    </div>
+  )
+}
+
 To monitor a new Postgres server with pganalyze, you must make some configuration changes
 to your database and install and run the pganalyze collector. There are two
 ways of doing this:
@@ -21,12 +37,4 @@ The guided setup program is our recommended way to set up on systems that meet t
 
 Otherwise, you'll need to follow the manual setup instructions.
 
-<Link className="btn btn-success" to="01_guided_setup">
-  Continue with guided setup
-</Link>
-<span style={{fontSize: '14px', marginLeft: '6px'}}>
-<span> or proceed with </span>
-<Link to="01_create_monitoring_user">
-  manual setup
-</Link>
-</span>
+<SetupOptions />

--- a/install/self_managed/04_configure_the_collector_docker.mdx
+++ b/install/self_managed/04_configure_the_collector_docker.mdx
@@ -9,15 +9,15 @@ import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_lin
 
 export const APIKeyInstructions = ({ apiKey }) => {
   return apiKey ? (
-    <>
+    <React.Fragment>
       The <code>PGA_API_KEY</code> for the current organization is{" "}
       <code>{apiKey}</code>
-    </>
+    </React.Fragment>
   ) : (
-    <>
+    <React.Fragment>
       The <code>PGA_API_KEY</code> can be found in the pganalyze API keys page
       for your organization
-    </>
+    </React.Fragment>
   );
 };
 

--- a/install/self_managed/04_configure_the_collector_package.mdx
+++ b/install/self_managed/04_configure_the_collector_package.mdx
@@ -9,15 +9,15 @@ import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_lin
 
 export const APIKeyInstructions = ({ apiKey }) => {
   return apiKey ? (
-    <>
+    <React.Fragment>
       The <code>api_key</code> for the current organization is{" "}
       <code>{apiKey}</code>
-    </>
+    </React.Fragment>
   ) : (
-    <>
+    <React.Fragment>
       The <code>api_key</code> can be found in the pganalyze API keys page for
       your organization
-    </>
+    </React.Fragment>
   );
 };
 


### PR DESCRIPTION
As part of the move to Vite.js, we need to upgrade in-app doc
rendering to @mdx-js/mdx v2, which seems to have some minor rendering
differences:

 - Some top-level React elements in MDX now always appear to render as
   display:block, so work around that with a wrapper element.
 - The '<>' shorthand for React.Fragment is no longer recognized. This
   will probably be fixed at some point, but for now, just use the long
   form.
 - The Postgres logo in the "select environment" overview is now very small
   (possibly since this is the only cell that stacks three lines); force
   dimensions similar to what we had before.
