### PR TITLE
Fix images after Gatsby v3 upgrade

### DIFF
--- a/explain/index.mdx
+++ b/explain/index.mdx
@@ -6,6 +6,8 @@ backlink_title: 'Documentation'
 
 import imgVisualization from './visualization.png'
 
+export const ImgVisualization = () => <img src={imgVisualization} alt="Plan Visualization Example" />
+
 ## The Basics
 
 First time looking at **EXPLAIN**, or trying to understand how query plans work?
@@ -27,7 +29,7 @@ Node types can be broadly considered in three categories:
 pganalyze includes built-in visualization of query plans, automatically collected from the Postgres logs:
 
 <a href="/postgres-explain">
-<img src={imgVisualization} alt="Plan Visualization Example" />
+  <ImgVisualization />
 </a>
 <br />
 

--- a/explain/setup/_verify_explain_public.mdx
+++ b/explain/setup/_verify_explain_public.mdx
@@ -1,13 +1,17 @@
 import imgLogExplainOverview from './log-explain-overview.png'
 import imgLogExplainDetails from './log-explain-details.png'
 
+export const ImgLogExplainOverview = () => <img src={imgLogExplainOverview} alt="Screenshot of EXPLAIN list in pganalyze" />
+
+export const ImgLogExplainDetails = () => <img src={imgLogExplainDetails} alt="Screenshot of EXPLAIN plan in pganalyze" />
+
 Assuming the collector is running in the background, after a few minutes you should then see an EXPLAIN plan show up in the pganalyze EXPLAIN plan list:
 
-<img src={imgLogExplainOverview} alt="Screenshot of EXPLAIN list in pganalyze" />
+<ImgLogExplainOverview />
 
 When you go to the details, you will find the corresponding plan:
 
-<img src={imgLogExplainDetails} alt="Screenshot of EXPLAIN plan in pganalyze" />
+<ImgLogExplainDetails />
 
 From now on, you will now get EXPLAIN plans automatically in the pganalyze UI, for all your slow queries.
 

--- a/explain/setup/amazon_rds/_02_actually_enable.mdx
+++ b/explain/setup/amazon_rds/_02_actually_enable.mdx
@@ -1,5 +1,6 @@
-
 import imgRDSReboot from '../../../images/rds_reboot.png'
+
+export const ImgRDSReboot = () => <img src={imgRDSReboot} alt="Restart your RDS database" />
 
 export const SPLRecommendation = ({recommendation}) => {
    if (recommendation.current == null) {
@@ -30,7 +31,7 @@ Since changes to `shared_preload_libraries` only take effect at server start, af
 these settings, you will need to restart Postgres. You can do so from the Actions menu in the
 AWS console:
 
-<img src={imgRDSReboot} alt="Restart your RDS database" />
+<ImgRDSReboot />
 
 After the reboot completes, verify that `shared_preload_libraries` now includes `auto_explain`
 and that the setting change does not require a restart (`pending_restart` should be `f`):

--- a/index-advisor/index.mdx
+++ b/index-advisor/index.mdx
@@ -7,12 +7,16 @@ backlink_title: 'Documentation'
 import imgIndexAdvisorInAppScreenshot from './index-advisor-in-app-screenshot.png'
 import imgIndexAdvisorArchitecture from './index-advisor-architecture.png'
 
+export const ImgIndexAdvisorInAppScreenshot = () => <img src={imgIndexAdvisorInAppScreenshot} alt="Index Advisor Screenshot" />
+
+export const ImgIndexAdvisorArchitecture = () => <img src={imgIndexAdvisorArchitecture} alt="Index Advisor Architecture Diagram" />
+
 The pganalyze Index Advisor is a tool to analyze your queries, determine how Postgres
 will scan the tables involved, and suggest indexes to make those scans more efficient.
 
 This page describes the in-app Index Advisor. Looking for the standalone Index Advisor documentation? [Continue here.](/docs/index-advisor/standalone)
 
-<img src={imgIndexAdvisorInAppScreenshot} alt="Index Advisor Screenshot" />
+<ImgIndexAdvisorInAppScreenshot />
 <br />
 
 ## Overview
@@ -48,7 +52,7 @@ table and index definitions and sizes), we can use this to analyze any query.
 
 The architecture of the index advisor roughly looks like this:
 
-<img src={imgIndexAdvisorArchitecture} alt="Index Advisor Architecture Diagram" />
+<ImgIndexAdvisorArchitecture />
 <br />
 
 

--- a/index-advisor/standalone/index.mdx
+++ b/index-advisor/standalone/index.mdx
@@ -6,10 +6,12 @@ backlink_title: 'Documentation'
 
 import imgIndexAdvisorScreenshot from './index-advisor-screenshot.png'
 
+export const ImgIndexAdvisorScreenshot = () => <img src={imgIndexAdvisorScreenshot} alt="Index Advisor Screenshot" />
+
 The pganalyze Index Advisor is a tool to analyze your queries, determine how Postgres
 will scan the tables involved, and suggest indexes to make those scans more efficient.
 
-<img src={imgIndexAdvisorScreenshot} alt="Index Advisor Screenshot" />
+<ImgIndexAdvisorScreenshot />
 <br />
 
 ## Overview

--- a/install/amazon_rds/03_setup_iam_policy.mdx
+++ b/install/amazon_rds/03_setup_iam_policy.mdx
@@ -7,7 +7,7 @@ backlink_title: 'Installation Guide'
 
 import imgRdsSetUpIamPolicy from "../../images/rds_iam_role.png"
 
-export const ImgWorkaround = (props) => <img {...props} />
+export const ImgRdsSetUpIamPolicy = () => <img src={imgRdsSetUpIamPolicy} width="520" style={{ border: "1px solid grey" }} />
 
 Almost done! 🎉
 
@@ -66,11 +66,7 @@ We recommend naming the policy "pganalyze" or similar, so you can easily identif
 To complete this step, [create an IAM role](https://console.aws.amazon.com/iam/home?#/roles$new?step=type)
 for pganalyze, and assign the policy to this new role.
 
-<ImgWorkaround
-  src={imgRdsSetUpIamPolicy}
-  width="520"
-  style={{ border: "1px solid grey" }}
-/>
+<ImgRdsSetUpIamPolicy />
 
 ---
 

--- a/install/amazon_rds/04_install_collector.mdx
+++ b/install/amazon_rds/04_install_collector.mdx
@@ -11,21 +11,27 @@ import imgAwsEc2 from '../../images/aws-ec2.svg'
 import imgAwsEcs from '../../images/aws-ecs.png'
 import imgDocker from '../../images/docker.png'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <div className={styles.installChoice}>
+      <Link className={styles.installChoiceStep} to="04_install_collector_ec2">
+        <img src={imgAwsEc2} />
+        Amazon EC2 Instance
+      </Link>
+      <Link className={styles.installChoiceStep} to="04_install_collector_ecs">
+        <img src={imgAwsEcs} />
+        Amazon ECS
+      </Link>
+      <Link className={styles.installChoiceStep} to="04_install_collector_docker">
+        <img src={imgDocker} />
+        Docker on EC2
+      </Link>
+    </div>
+  )
+}
+
 The [pganalyze collector](https://pganalyze.com/docs/collector) is a daemon process that continuously collects database statistics, and submits them to the pganalyze dashboard in recurring intervals.
 
 We recommend installing the collector on an EC2 instance, but you can also run it through a Docker container:
 
-<div className={styles.installChoice}>
-  <Link className={styles.installChoiceStep} to="04_install_collector_ec2">
-    <img src={imgAwsEc2} />
-    Amazon EC2 Instance
-  </Link>
-  <Link className={styles.installChoiceStep} to="04_install_collector_ecs">
-    <img src={imgAwsEcs} />
-    Amazon ECS
-  </Link>
-  <Link className={styles.installChoiceStep} to="04_install_collector_docker">
-    <img src={imgDocker} />
-    Docker on EC2
-  </Link>
-</div>
+<SelectCollectorPlatform />

--- a/install/amazon_rds/04_install_collector_ec2.mdx
+++ b/install/amazon_rds/04_install_collector_ec2.mdx
@@ -9,6 +9,8 @@ import CollectorInstallInstructions from "../../components/CollectorInstallInstr
 
 import imgRdsNewInstanceRole from "../../images/rds_new_instance_role.png"
 
+export const ImgRdsNewInstanceRole = () => <img src={imgRdsNewInstanceRole} width="694.4" />
+
 ## Installing the collector on an Amazon EC2 Instance
 
 For this step, you first need to choose whether you want to install the collector on an existing EC2 instance, or run a new one.
@@ -22,7 +24,7 @@ You can either run it on a small instance (a `t3.small` suffices), or add it to 
 Start a new `t3.small` instance, Amazon Linux 2 based, that has the IAM role applied:
 
 <p>
-  <img src={imgRdsNewInstanceRole} width="694.4" />
+  <ImgRdsNewInstanceRole />
 </p>
 
 Then follow the step to install the collector on Amazon Linux 2 based instances.

--- a/install/amazon_rds/05_configure_the_collector.mdx
+++ b/install/amazon_rds/05_configure_the_collector.mdx
@@ -11,19 +11,25 @@ import imgAwsEc2 from '../../images/aws-ec2.svg'
 import imgAwsEcs from '../../images/aws-ecs.png'
 import imgDocker from '../../images/docker.png'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <div className={styles.installChoice}>
+      <Link className={styles.installChoiceStep} to="05_configure_the_collector_ec2">
+        <img src={imgAwsEc2} />
+        Amazon EC2 Instance
+      </Link>
+      <Link className={styles.installChoiceStep} to="05_configure_the_collector_ecs">
+        <img src={imgAwsEcs} />
+        Amazon ECS
+      </Link>
+      <Link className={styles.installChoiceStep} to="05_configure_the_collector_docker">
+        <img src={imgDocker} />
+        Docker on EC2
+      </Link>
+    </div>
+  )
+}
+
 Choose where you have installed the collector:
 
-<div className={styles.installChoice}>
-  <Link className={styles.installChoiceStep} to="05_configure_the_collector_ec2">
-    <img src={imgAwsEc2} />
-    Amazon EC2 Instance
-  </Link>
-  <Link className={styles.installChoiceStep} to="05_configure_the_collector_ecs">
-    <img src={imgAwsEcs} />
-    Amazon ECS
-  </Link>
-  <Link className={styles.installChoiceStep} to="05_configure_the_collector_docker">
-    <img src={imgDocker} />
-    Docker on EC2
-  </Link>
-</div>
+<SelectCollectorPlatform />

--- a/install/amazon_rds/_01_public.mdx
+++ b/install/amazon_rds/_01_public.mdx
@@ -2,7 +2,14 @@ import imgRdsParamGroup from '../../images/rds_parameter_group.png'
 import imgRdsParamGroup2 from '../../images/rds_parameter_group2.gif'
 import imgRdsEnableParamGroup from '../../images/rds_enable_parameter_group.png'
 
-In order to setup pganalyze monitoring for [Amazon RDS](https://aws.amazon.com/rds/postgresql/) you'll need
+export const ImgRdsParamGroup = () => <img src={imgRdsParamGroup} />
+
+export const ImgRdsParamGroup2 = () => <img src={imgRdsParamGroup2} />
+
+export const ImgRdsEnableParamGroup = () => <img src={imgRdsEnableParamGroup} />
+
+
+In order to set up pganalyze monitoring for [Amazon RDS](https://aws.amazon.com/rds/postgresql/) you'll need
 to first follow these steps to enable the [pg\_stat\_statements](http://www.postgresql.org/docs/current/static/pgstatstatements.html)
 extension for collecting query statistics.
 
@@ -14,13 +21,13 @@ This guide assumes you have an already running Amazon RDS PostgreSQL server you 
 
 In your [AWS Console](https://console.aws.amazon.com/rds/), modify your existing custom DB Parameter Group, or create a new custom DB Parameter Group:
 
-<img src={imgRdsParamGroup} />
+<ImgRdsParamGroup />
 
 ---
 
 Then set the following configuration parameters:
 
-<img src={imgRdsParamGroup2} />
+<ImgRdsParamGroup2 />
 
  Name | New Value | &nbsp;
  ---- | ------ | -------
@@ -32,7 +39,7 @@ Then set the following configuration parameters:
 
 In case you created a new parameter group you'll have to modify your database to use the Parameter Group you created earlier:<br />
 
-<img src={imgRdsEnableParamGroup} />
+<ImgRdsEnableParamGroup />
 
 ## Enable Enhanced Monitoring
 

--- a/install/azure_database/02_install_the_collector.mdx
+++ b/install/azure_database/02_install_the_collector.mdx
@@ -11,21 +11,27 @@ import imgLogoUbuntu from '../../images/logo_ubuntu.png'
 import imgLogoRedhat from '../../images/logo_redhat.png'
 import imgLogoDocker from '../../images/docker.png'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <div className={styles.installChoice}>
+      <Link className={styles.installChoiceStep} to="02_install_the_collector_deb">
+        <img src={imgLogoUbuntu} />
+        Ubuntu &amp; Debian VM
+      </Link>
+      <Link className={styles.installChoiceStep} to="02_install_the_collector_yum">
+        <img src={imgLogoRedhat} />
+        RHEL, CentOS &amp; Fedora VM
+      </Link>
+      <Link className={styles.installChoiceStep} to="02_install_the_collector_docker">
+        <img src={imgLogoDocker} />
+        Docker
+      </Link>
+    </div>
+  )
+}
+
 To continue, we need to know where you'd like to install the pganalyze collector.
 
 The collector runs on a virtual machine or container and connects to your Azure Database for PostgreSQL server:
 
-<div className={styles.installChoice}>
-  <Link className={styles.installChoiceStep} to="02_install_the_collector_deb">
-    <img src={imgLogoUbuntu} />
-    Ubuntu &amp; Debian VM
-  </Link>
-  <Link className={styles.installChoiceStep} to="02_install_the_collector_yum">
-    <img src={imgLogoRedhat} />
-    RHEL, CentOS &amp; Fedora VM
-  </Link>
-  <Link className={styles.installChoiceStep} to="02_install_the_collector_docker">
-    <img src={imgLogoDocker} />
-    Docker
-  </Link>
-</div>
+<SelectCollectorPlatform />

--- a/install/azure_database/03_configure_the_collector.mdx
+++ b/install/azure_database/03_configure_the_collector.mdx
@@ -11,28 +11,34 @@ import imgLogoUbuntu from '../../images/logo_ubuntu.png'
 import imgLogoRedhat from '../../images/logo_redhat.png'
 import imgLogoDocker from '../../images/docker.png'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <div className={styles.installChoice}>
+      <Link
+        className={styles.installChoiceStep}
+        to="03_configure_the_collector_package"
+      >
+        <img src={imgLogoUbuntu} />
+        Ubuntu &amp; Debian
+      </Link>
+      <Link
+        className={styles.installChoiceStep}
+        to="03_configure_the_collector_package"
+      >
+        <img src={imgLogoRedhat} />
+        RHEL, CentOS &amp; Fedora
+      </Link>
+      <Link className={styles.installChoiceStep} to="03_configure_the_collector_docker">
+        <img src={imgLogoDocker} />
+        Docker
+      </Link>
+    </div>
+  )
+}
+
 To continue, we need to know where your Postgres is running:
 
-<div className={styles.installChoice}>
-  <Link
-    className={styles.installChoiceStep}
-    to="03_configure_the_collector_package"
-  >
-    <img src={imgLogoUbuntu} />
-    Ubuntu &amp; Debian
-  </Link>
-  <Link
-    className={styles.installChoiceStep}
-    to="03_configure_the_collector_package"
-  >
-    <img src={imgLogoRedhat} />
-    RHEL, CentOS &amp; Fedora
-  </Link>
-  <Link className={styles.installChoiceStep} to="03_configure_the_collector_docker">
-    <img src={imgLogoDocker} />
-    Docker
-  </Link>
-</div>
+<SelectCollectorPlatform />
 
 <br />
 If your Postgres runs somewhere else, <a href="mailto:support@pganalyze.com">

--- a/install/google_cloud_sql/02_install_the_collector.mdx
+++ b/install/google_cloud_sql/02_install_the_collector.mdx
@@ -11,25 +11,31 @@ import imgLogoUbuntu from '../../images/logo_ubuntu.png'
 import imgLogoRedhat from '../../images/logo_redhat.png'
 import imgLogoDocker from '../../images/docker.png'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <div className={styles.installChoice}>
+      <Link className={styles.installChoiceStep} to="02_install_the_collector_deb">
+        <img src={imgLogoUbuntu} />
+        Ubuntu &amp; Debian VM
+      </Link>
+      <Link className={styles.installChoiceStep} to="02_install_the_collector_yum">
+        <img src={imgLogoRedhat} />
+        RHEL, CentOS &amp; Fedora VM
+      </Link>
+      <Link className={styles.installChoiceStep} to="02_install_the_collector_docker">
+        <img src={imgLogoDocker} />
+        Docker
+      </Link>
+      {/*<Link className={styles.installChoiceStep} to="02_enable_pg_stat_statements_kubernetes">
+        <img src="/images/docs/logo_kubernetes.png" />
+        Kubernetes
+      </Link>*/}
+    </div>
+  )
+}
+
 To continue, we need to know where you'd like to install the pganalyze collector.
 
 The collector needs to run on a virtual machine or container and be able to reach your Google Cloud SQL database:
 
-<div className={styles.installChoice}>
-  <Link className={styles.installChoiceStep} to="02_install_the_collector_deb">
-    <img src={imgLogoUbuntu} />
-    Ubuntu &amp; Debian VM
-  </Link>
-  <Link className={styles.installChoiceStep} to="02_install_the_collector_yum">
-    <img src={imgLogoRedhat} />
-    RHEL, CentOS &amp; Fedora VM
-  </Link>
-  <Link className={styles.installChoiceStep} to="02_install_the_collector_docker">
-    <img src={imgLogoDocker} />
-    Docker
-  </Link>
-  {/*<Link className={styles.installChoiceStep} to="02_enable_pg_stat_statements_kubernetes">
-    <img src="/images/docs/logo_kubernetes.png" />
-    Kubernetes
-  </Link>*/}
-</div>
+<SelectCollectorPlatform />

--- a/install/google_cloud_sql/03_configure_the_collector.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector.mdx
@@ -11,32 +11,38 @@ import imgLogoUbuntu from '../../images/logo_ubuntu.png'
 import imgLogoRedhat from '../../images/logo_redhat.png'
 import imgLogoDocker from '../../images/docker.png'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <div className={styles.installChoice}>
+      <Link
+        className={styles.installChoiceStep}
+        to="03_configure_the_collector_package"
+      >
+        <img src={imgLogoUbuntu} />
+        Ubuntu &amp; Debian
+      </Link>
+      <Link
+        className={styles.installChoiceStep}
+        to="03_configure_the_collector_package"
+      >
+        <img src={imgLogoRedhat} />
+        RHEL, CentOS &amp; Fedora
+      </Link>
+      <Link className={styles.installChoiceStep} to="03_configure_the_collector_docker">
+        <img src={imgLogoDocker} />
+        Docker
+      </Link>
+      {/*<Link className={styles.installChoiceStep} to="03_configure_the_collector_kubernetes">
+        <img src="/images/docs/logo_kubernetes.png" />
+        Kubernetes
+      </Link>*/}
+    </div>
+  )
+}
+
 To continue, we need to know where your Postgres is running:
 
-<div className={styles.installChoice}>
-  <Link
-    className={styles.installChoiceStep}
-    to="03_configure_the_collector_package"
-  >
-    <img src={imgLogoUbuntu} />
-    Ubuntu &amp; Debian
-  </Link>
-  <Link
-    className={styles.installChoiceStep}
-    to="03_configure_the_collector_package"
-  >
-    <img src={imgLogoRedhat} />
-    RHEL, CentOS &amp; Fedora
-  </Link>
-  <Link className={styles.installChoiceStep} to="03_configure_the_collector_docker">
-    <img src={imgLogoDocker} />
-    Docker
-  </Link>
-  {/*<Link className={styles.installChoiceStep} to="03_configure_the_collector_kubernetes">
-    <img src="/images/docs/logo_kubernetes.png" />
-    Kubernetes
-  </Link>*/}
-</div>
+<SelectCollectorPlatform />
 
 <br />
 If your Postgres runs somewhere else, <a href="mailto:support@pganalyze.com">

--- a/install/self_managed/02_enable_pg_stat_statements.mdx
+++ b/install/self_managed/02_enable_pg_stat_statements.mdx
@@ -12,36 +12,44 @@ import imgLogoRedhat from '../../images/logo_redhat.png'
 import imgLogoDocker from '../../images/docker.png'
 import imgLogoAL2 from '../../images/aws-ec2.svg'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <React.Fragment>
+      <div className={styles.installChoice}>
+        <Link className={styles.installChoiceStep} to="02_enable_pg_stat_statements_deb">
+          <img src={imgLogoUbuntu} />
+          Ubuntu &amp; Debian
+        </Link>
+        <Link className={styles.installChoiceStep} to="02_enable_pg_stat_statements_yum">
+          <img src={imgLogoRedhat} />
+          RHEL, CentOS &amp; Fedora
+        </Link>
+      </div>
+      <div className={styles.installChoice}>
+        <Link
+          className={styles.installChoiceStep}
+          to="02_enable_pg_stat_statements_yum"
+        >
+          <img src={imgLogoAL2} />
+          Amazon Linux 2
+        </Link>
+        <Link
+          className={styles.installChoiceStep}
+          to="02_enable_pg_stat_statements_docker"
+        >
+          <img src={imgLogoDocker} />
+          Docker
+        </Link>
+      </div>
+    </React.Fragment>
+  )
+}
+
 In this step we setup [pg_stat_statements](http://www.postgresql.org/docs/current/static/pgstatstatements.html), which is used by pganalyze to collect Postgres query statistics.
 
 To continue, we need to know where your Postgres is running:
 
-<div className={styles.installChoice}>
-  <Link className={styles.installChoiceStep} to="02_enable_pg_stat_statements_deb">
-    <img src={imgLogoUbuntu} />
-    Ubuntu &amp; Debian
-  </Link>
-  <Link className={styles.installChoiceStep} to="02_enable_pg_stat_statements_yum">
-    <img src={imgLogoRedhat} />
-    RHEL, CentOS &amp; Fedora
-  </Link>
-</div>
-<div className={styles.installChoice}>
-  <Link
-    className={styles.installChoiceStep}
-    to="02_enable_pg_stat_statements_yum"
-  >
-    <img src={imgLogoAL2} />
-    Amazon Linux 2
-  </Link>
-  <Link
-    className={styles.installChoiceStep}
-    to="02_enable_pg_stat_statements_docker"
-  >
-    <img src={imgLogoDocker} />
-    Docker
-  </Link>
-</div>
+<SelectCollectorPlatform />
 
 <br />
 If your Postgres runs somewhere else, <a href="mailto:support@pganalyze.com">

--- a/install/self_managed/03_install_the_collector.mdx
+++ b/install/self_managed/03_install_the_collector.mdx
@@ -11,26 +11,32 @@ import imgLogoUbuntu from '../../images/logo_ubuntu.png'
 import imgLogoRedhat from '../../images/logo_redhat.png'
 import imgLogoDocker from '../../images/docker.png'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <div className={styles.installChoice}>
+      <Link className={styles.installChoiceStep} to="03_install_the_collector_deb">
+        <img src={imgLogoUbuntu} />
+        Ubuntu &amp; Debian
+      </Link>
+      <Link className={styles.installChoiceStep} to="03_install_the_collector_yum">
+        <img src={imgLogoRedhat} />
+        RHEL, CentOS &amp; Fedora
+      </Link>
+      <Link className={styles.installChoiceStep} to="03_install_the_collector_docker">
+        <img src={imgLogoDocker} />
+        Docker
+      </Link>
+      {/*<Link className={styles.installChoiceStep} to="03_enable_pg_stat_statements_kubernetes">
+        <img src="/images/docs/logo_kubernetes.png" />
+        Kubernetes
+      </Link>*/}
+    </div>
+  )
+}
+
 To continue, we need to know where your Postgres is running:
 
-<div className={styles.installChoice}>
-  <Link className={styles.installChoiceStep} to="03_install_the_collector_deb">
-    <img src={imgLogoUbuntu} />
-    Ubuntu &amp; Debian
-  </Link>
-  <Link className={styles.installChoiceStep} to="03_install_the_collector_yum">
-    <img src={imgLogoRedhat} />
-    RHEL, CentOS &amp; Fedora
-  </Link>
-  <Link className={styles.installChoiceStep} to="03_install_the_collector_docker">
-    <img src={imgLogoDocker} />
-    Docker
-  </Link>
-  {/*<Link className={styles.installChoiceStep} to="03_enable_pg_stat_statements_kubernetes">
-    <img src="/images/docs/logo_kubernetes.png" />
-    Kubernetes
-  </Link>*/}
-</div>
+<SelectCollectorPlatform />
 
 <br />
 If your Postgres runs somewhere else, <a href="mailto:support@pganalyze.com">

--- a/install/self_managed/04_configure_the_collector.mdx
+++ b/install/self_managed/04_configure_the_collector.mdx
@@ -11,32 +11,38 @@ import imgLogoUbuntu from '../../images/logo_ubuntu.png'
 import imgLogoRedhat from '../../images/logo_redhat.png'
 import imgLogoDocker from '../../images/docker.png'
 
+export const SelectCollectorPlatform = () => {
+  return (
+    <div className={styles.installChoice}>
+      <Link
+        className={styles.installChoiceStep}
+        to="04_configure_the_collector_package"
+      >
+        <img src={imgLogoUbuntu} />
+        Ubuntu &amp; Debian
+      </Link>
+      <Link
+        className={styles.installChoiceStep}
+        to="04_configure_the_collector_package"
+      >
+        <img src={imgLogoRedhat} />
+        RHEL, CentOS &amp; Fedora
+      </Link>
+      <Link className={styles.installChoiceStep} to="04_configure_the_collector_docker">
+        <img src={imgLogoDocker} />
+        Docker
+      </Link>
+      {/*<Link className={styles.installChoiceStep} to="03_enable_pg_stat_statements_kubernetes">
+        <img src="/images/docs/logo_kubernetes.png" />
+        Kubernetes
+      </Link>*/}
+    </div>
+  )
+}
+
 To continue, we need to know where your Postgres is running:
 
-<div className={styles.installChoice}>
-  <Link
-    className={styles.installChoiceStep}
-    to="04_configure_the_collector_package"
-  >
-    <img src={imgLogoUbuntu} />
-    Ubuntu &amp; Debian
-  </Link>
-  <Link
-    className={styles.installChoiceStep}
-    to="04_configure_the_collector_package"
-  >
-    <img src={imgLogoRedhat} />
-    RHEL, CentOS &amp; Fedora
-  </Link>
-  <Link className={styles.installChoiceStep} to="04_configure_the_collector_docker">
-    <img src={imgLogoDocker} />
-    Docker
-  </Link>
-  {/*<Link className={styles.installChoiceStep} to="03_enable_pg_stat_statements_kubernetes">
-    <img src="/images/docs/logo_kubernetes.png" />
-    Kubernetes
-  </Link>*/}
-</div>
+<SelectCollectorPlatform />
 
 <br />
 If your Postgres runs somewhere else, <a href="mailto:support@pganalyze.com">

--- a/log-insights/setup/amazon-rds/01_test_log_download.mdx
+++ b/log-insights/setup/amazon-rds/01_test_log_download.mdx
@@ -7,6 +7,8 @@ backlink_title: 'Log Insights: Setup'
 
 import imgLogInsightsScreenshot from '../log_insights_screenshot.png'
 
+export const ImgLogInsightsScreenshot = () => <img src={imgLogInsightsScreenshot} alt='Screenshot of pganalyze Log Insights feature' />
+
 Log Insights works by continuously fetching your Postgres log files from AWS, classifying log
 lines, and submitting log data and statistics to pganalyze. The RDS configuration usually
 does not require any additional configuration beyond the steps you performed as part of basic
@@ -59,7 +61,7 @@ In case you get permission errors, make sure your IAM user has the [appropriate 
 <PublicOnly>
   <p>You will then see Log Insights data on your database within a few minutes:</p>
   <p>
-    <img src={imgLogInsightsScreenshot} alt='Screenshot of pganalyze Log Insights feature' />
+    <ImgLogInsightsScreenshot />
   </p>
   <p>
     We recommend that you also <a href="https://pganalyze.com/docs/log-insights/setup/tuning-log-config-settings">tune a

--- a/log-insights/setup/azure-database/01_set_up_managed_identity.mdx
+++ b/log-insights/setup/azure-database/01_set_up_managed_identity.mdx
@@ -7,13 +7,15 @@ backlink_title: 'Log Insights: Setup'
 
 import imgManagedIdentityVMAssignment from './managed-identity-vm-assignment.png'
 
+export const ImgManagedIdentityVMAssignment = () => <img src={imgManagedIdentityVMAssignment} alt="Screenshot of Virtual Machine Identity configuration in Azure Portal" />
+
 Log output on Azure Database for PostgreSQL is available through Azure Event Hub.
 
 To start, we need to [create a new user-assigned Managed Identity](https://portal.azure.com/#create/Microsoft.ManagedIdentity) through the Azure Portal.
 
 After the Managed Identity is created, assign it to your virtual machine:
 
-<img src={imgManagedIdentityVMAssignment} alt="Screenshot of Virtual Machine Identity configuration in Azure Portal" />
+<ImgManagedIdentityVMAssignment />
 
 Now the pganalyze collector running inside the virtual machine will be able to call Azure REST APIs using the Managed Identity.
 

--- a/log-insights/setup/azure-database/02_set_up_azure_event_hub.mdx
+++ b/log-insights/setup/azure-database/02_set_up_azure_event_hub.mdx
@@ -8,6 +8,10 @@ backlink_title: 'Log Insights: Setup'
 import imgCreateEventHub from './create-event-hub.png'
 import imgAddEventHubPermission from './add-event-hub-permission.png'
 
+export const ImgCreateEventHub = () => <img src={imgCreateEventHub} alt="Screenshot of Create Event Hub in Azure Portal" />
+
+export const ImgAddEventHubPermission = () => <img src={imgAddEventHubPermission} alt="Screenshot of adding Azure Event Hubs Data Receiver Permission to Managed Identity in Azure Portal" />
+
 In order to retrieve logs from your database server continuously, the pganalyze collector utilizes an Azure Event Hub in your account.
 
 To start, create a new [Azure Event Hub namespace](https://portal.azure.com/#create/Microsoft.EventHub), using the Basic pricing tier.
@@ -15,12 +19,12 @@ To start, create a new [Azure Event Hub namespace](https://portal.azure.com/#cre
 Next, create an Event Hub inside the namespace, using the standard partition count (2):
 
 <p style={{maxWidth: '400px'}}>
-  <img src={imgCreateEventHub} alt="Screenshot of Create Event Hub in Azure Portal" />
+  <ImgCreateEventHub />
 </p>
 
 Within the Event Hub, grant the "Azure Event Hubs Data Receiver" permission for the Managed Identity (or Azure AD application) we created earlier:
 
-<img src={imgAddEventHubPermission} alt="Screenshot of adding Azure Event Hubs Data Receiver Permission to Managed Identity in Azure Portal" />
+<ImgAddEventHubPermission />
 
 Now the pganalyze collector will be able to read log data that is sent into the Azure Event Hub.
 

--- a/log-insights/setup/azure-database/03_stream_logs_into_event_hub.mdx
+++ b/log-insights/setup/azure-database/03_stream_logs_into_event_hub.mdx
@@ -7,12 +7,14 @@ backlink_title: 'Log Insights: Setup'
 
 import imgAddDiagnosticSetting from './add-diagnostic-setting.png'
 
+export const ImgAddDiagnosticSetting = () => <img src={imgAddDiagnosticSetting} alt="Screenshot of adding PostgreSQL Diagnostic Setting in Azure Portal" />
+
 To send logs to the Event Hub, within your database server, go to Diagnostic settings, and add a new diagnostic setting:
 
 * **Category Details:** Select "PostgreSQLLogs" under "log"
 * **Destination Details:** Select "Stream to an event hub", and then select your Event Hub Namespace and Event Hub Name
 
-<img src={imgAddDiagnosticSetting} alt="Screenshot of adding PostgreSQL Diagnostic Setting in Azure Portal" />
+<ImgAddDiagnosticSetting />
 
 Save the new diagnostic setting. Now your Event Hub should be receiving Postgres log messages.
 

--- a/log-insights/setup/google-cloud-sql/02_configure_log_routing.mdx
+++ b/log-insights/setup/google-cloud-sql/02_configure_log_routing.mdx
@@ -7,13 +7,15 @@ backlink_title: 'Log Insights: Setup'
 
 import imgCreateLogSink from './create-log-sink.png'
 
+export const ImgCreateLogSink = () => <img src={imgCreateLogSink} alt="Screenshot of creating a log sink in Google Cloud Console" />
+
 Navigate to your Cloud SQL database instance, click on "View PostgreSQL error logs", and then click on "Logs Router".
 
 Click "Create Sink", and select your Pub/Sub topic. Make sure that the left side is actually
 showing PostgreSQL logs (as it does in this screenshot), and that you don't have a different
 type of resource selected:
 
-<img src={imgCreateLogSink} alt="Screenshot of creating a log sink in Google Cloud Console" />
+<ImgCreateLogSink />
 
 Now we need to create a service account that can access the logs sent to the Pub/Sub topic.
 

--- a/log-insights/setup/heroku-postgres/03_restart_collector.mdx
+++ b/log-insights/setup/heroku-postgres/03_restart_collector.mdx
@@ -7,6 +7,8 @@ backlink_title: 'Log Insights: Setup'
 
 import imgLogInsights from './log_insights.png'
 
+export const ImgLogInsights = () => <img src={imgLogInsights} alt='Screenshot of pganalyze Log Insights feature' />
+
 To finish, restart the collector app:
 
 ```bash
@@ -28,7 +30,7 @@ If the collector was able to match the log data to the correct database, you wil
 <PublicOnly>
   <p>And then when you check the pganalyze interface, you will see Log Insights data:</p>
   <p>
-    <img src={imgLogInsights} alt='Screenshot of pganalyze Log Insights feature' />
+    <ImgLogInsights />
   </p>
 </PublicOnly>
 

--- a/log-insights/setup/self-managed/02_configure_collector.mdx
+++ b/log-insights/setup/self-managed/02_configure_collector.mdx
@@ -7,6 +7,8 @@ backlink_title: 'Log Insights: Setup'
 
 import imgLogInsightsScreenshot from '../log_insights_screenshot.png'
 
+export const ImgLogInsightsScreenshot = () => <img src={imgLogInsightsScreenshot} alt='Screenshot of pganalyze Log Insights feature' />
+
 We can now configure the log directory for the collector, by adding the `db_log_location` setting,
 similar to this:
 
@@ -48,7 +50,7 @@ sudo systemctl restart pganalyze-collector
     Once ready, you will see log events on the Log Insights page in pganalyze.
   </p>
   <p>
-    <img src={imgLogInsightsScreenshot} alt='Screenshot of pganalyze Log Insights feature' />
+    <ImgLogInsightsScreenshot />
   </p>
   <p>
     We recommend setting up <a href="/docs/explain/setup">Automated EXPLAIN</a> as


### PR DESCRIPTION
It looks like the MDX handling changed in such a way that sometimes
breaks the syntax we were using in most places for handling images:

    import imgPath from '../path/to/image'

    <img src={imgPath} />

This does still work in some places, but it's not clear what details
of the MDX structure affect what works and what doesn't.

Instead, create one-off components wrapping images in these MDX files,
which reliably works around the issue.
