### PR TITLE
Fix rendering of self-managed install button in Chrome

### DIFF
--- a/install.mdx
+++ b/install.mdx
@@ -49,10 +49,9 @@ To continue please select in which environment you are running your Postgres dat
     className={styles.installChoiceStep}
     to="install/self_managed/00_choose_setup_method"
   >
-    <img style={{width: "16px", height: "21px"}} src={imgLogoPgsql} />
+    <img src={imgLogoPgsql} />
     Self-Managed
-    <br />
-    <small style={{ marginTop: "-5px", fontSize: "12px" }}>
+    <small style={{ marginTop: "-15px", fontSize: "12px" }}>
       VM / Container / On-Premise
     </small>
   </Link>


### PR DESCRIPTION
Some of the MDX changes in the Vite upgrade led to the explanatory
text rendering out of the box in Chrome. The CSS here is a bit
tortured, but I couldn't figure out a simple way to straighten this
out. For now, just drop the explicit image dimensions, drop the line
break (which does not make much sense in a flexbox context anyway),
and increase the negative margin to have this match current prod.
