### PR TITLE
Update docs for Postgres 14

### DIFF
--- a/components/PgContribPkgInstallInstructions.tsx
+++ b/components/PgContribPkgInstallInstructions.tsx
@@ -4,7 +4,7 @@ import { useCodeBlock } from './CodeBlock';
 import TabPanel, { TabItem } from './TabPanel'
 
 const PgContribPkgInstallInstructions: React.FunctionComponent = () => {
-  const versions: string[] = [ '13', '12', '11', '10', '9.6' ];
+  const versions: string[] = [ '14', '13', '12', '11', '10', '9.6' ];
   const tabs = versions.map<TabItem>(version => {
     const id = `pg${version.replace(/\D/, '')}`
     const label = `Postgres ${version}`


### PR DESCRIPTION
Ensure we show the Postgres 14 package option.

This turned out to be drastically easier than I expected, since in
most places, the instructions for Postgres 10+ are identical, and
nothing breaks that in 14.