### PR TITLE
Add index recommendation URL to issue guidance URLs

### DIFF
--- a/components/CheckDocumentation/queries/Slowness.tsx
+++ b/components/CheckDocumentation/queries/Slowness.tsx
@@ -28,6 +28,7 @@ const SlownessGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
   urls: {
     firstReferenceUrl,
     queriesUrl,
+    indexRecommendationUrl,
     serverSystemUrl,
     serverVacuumsUrl,
     databaseWaitEventsUrl,
@@ -66,7 +67,7 @@ const SlownessGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
             If a query lacks the necessary indexes to execute efficiently, it
             may take longer and use more I/O than necessary, causing a negative
             impact on the whole system. Check the{" "}
-            <Link to={featureUrl(firstReferenceUrl, 'indexcheck')}>query page</Link> to review
+            <Link to={indexRecommendationUrl}>query page</Link> to review
             indexing recommendations.
           </p>
         </li>

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -217,6 +217,7 @@ export type IssueGuidanceUrls = {
   firstReferenceUrl: string;
   SettingLink: React.ComponentType<{ setting: string }>;
   queriesUrl: string;
+  indexRecommendationUrl: string;
   serverSystemUrl: string;
   serverVacuumsUrl: string;
   backendsUrl: string;


### PR DESCRIPTION
This lets us link to the index advisor when a plan supports it or to
the index check otherwise.
