### PR TITLE
Upgrade to highlight.js 11 to fix errors

### DIFF
--- a/components/SQL/index.tsx
+++ b/components/SQL/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import hljs from "highlight.js/lib/highlight";
+import hljs from "highlight.js/lib/core";
 import sql from "highlight.js/lib/languages/sql";
 
 import styles from "./style.module.scss";


### PR DESCRIPTION
We upgraded highlight.js to 10 during our Gatsby upgrade and something
broke. Since 11 appears to work with only minor changes, update the
imports to support that.
