### PR TITLE
Fix className handling in SmartAnchor

### DIFF
--- a/components/SmartAnchor.tsx
+++ b/components/SmartAnchor.tsx
@@ -1,6 +1,8 @@
 import React, { useContext } from "react";
 import { useIcon } from "./WithIcons";
 
+import classNames from "classnames";
+
 import styles from './style.module.scss';
 
 type AnchorProps = React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
@@ -58,13 +60,12 @@ const SmartAnchor: React.FunctionComponent<Props> = ({linkComponent, linkRelativ
     }
 
     const { children, className, ...otherProps } = props;
-    const mergedClassname = styles.noWrap + (className === null ? '' : ' ' + className);
     // Don't show external icon link in some situations
     const skipExternalLinkIcon = destination.startsWith('https://heroku.com/deploy')
       || destination.startsWith('#')
       || destination.startsWith('mailto:')
     return (
-      <a {...otherProps} className={mergedClassname}>
+      <a {...otherProps} className={classNames(styles.noWrap, className)}>
         {children}{!skipExternalLinkIcon && <ExternaLinkIcon className={styles.externalLinkIcon} />}
       </a>
     )


### PR DESCRIPTION
SmartAnchor has a mostly-innocuous bug right now where it will add a
bogus 'undefined' class name if the className prop is not specified or
set to 'undefined'. This is a bug in its className handling, which was
bespoke and not relying on the classNames package because it seemed
odd for docs to depend on packages without declaring its own
dependencies.

However, given classNames is present in all current consumers, and is
a fairly small and broadly useful package, rely on it instead to avoid
future bugs and improve readability.
