### PR TITLE
Address highlight.js 11 warning

### DIFF
--- a/components/SQL/index.tsx
+++ b/components/SQL/index.tsx
@@ -40,7 +40,7 @@ class SQL extends React.Component<Props> {
   componentDidMount() {
     if (this.preRef) {
       hljs.registerLanguage("sql", sql);
-      this.preRef && hljs.highlightBlock(this.preRef);
+      this.preRef && hljs.highlightElement(this.preRef);
 
       this.preRef &&
         this.preRef


### PR DESCRIPTION
The highlightBlock method is deprecated and will be removed in 12
according to a console warning from the upgraded highlight.js.

Use the renamed alternative.
