### PR TITLE
Guided setup: Remove link to manual pkgs, instead point to manual setup

### DIFF
--- a/components/CollectorInstallInstructions.tsx
+++ b/components/CollectorInstallInstructions.tsx
@@ -17,12 +17,13 @@ const CollectorInstallInstructions: React.FunctionComponent<Props> = ({apiKey, g
     env['PGA_GUIDED_SETUP'] = 'true'
   }
 
-  return <CollectorEnvInstallInstructions env={env} />
+  return <CollectorEnvInstallInstructions env={env} hideManualInstall={guided} />
 }
 
 const CollectorEnvInstallInstructions: React.FunctionComponent<{
-  env: { [key: string]: string }
-}> = ({env}) => {
+  env: { [key: string]: string },
+  hideManualInstall?: boolean,
+}> = ({env, hideManualInstall}) => {
   const CodeBlock = useCodeBlock();
   let bashCmd: string;
   if (Object.keys(env).length === 0) {
@@ -34,17 +35,17 @@ const CollectorEnvInstallInstructions: React.FunctionComponent<{
   }
   return (
     <>
-      <p>
+      {!hideManualInstall && <p>
         We recommend running our install script to automatically detect your platform and
         install the correct package:
-      </p>
+      </p>}
       <CodeBlock>
         curl https://packages.pganalyze.com/collector-install.sh | {bashCmd}
       </CodeBlock>
       <RepositorySigningKey small />
-      <p>
+      {!hideManualInstall && <p>
         Alternately, you can follow the <a href="https://pganalyze.com/docs/collector/packages">manual install instructions</a>.
-      </p>
+      </p>}
     </>
   )
 }

--- a/install/self_managed/01_guided_setup.mdx
+++ b/install/self_managed/01_guided_setup.mdx
@@ -10,8 +10,8 @@ import CollectorInstallInstructions from '../../components/CollectorInstallInstr
 To begin guided setup, you'll need to install the collector, which sends statistics information
 and query activity to pganalyze.
 
-Note that guided setup is supported for Ubuntu 14.04 or newer or Debian 10 or newer. If you are
-running an older version, please follow the manual setup instructions.
+Note that guided setup is **only supported for Ubuntu 16.04 or newer or Debian 10 or newer.** If you are
+running an older version, or using a RHEL/CentOS/Amazon Linux 2 system please follow the <Link to="01_create_monitoring_user">manual setup instructions</Link>.
 
 You will need an API key for the install. <PublicOnly>It can be found in the pganalyze Settings page for your organization.</PublicOnly><InAppOnly>It is included in the command below.</InAppOnly>
 


### PR DESCRIPTION
The main choice that one makes here is "guided" vs "manual" setup,
and the page offered no clear way to go back to the manual setup
when exploring the guided setup option.

Additionally, there was a confusingly worded text adjacent to the install
script. Since we don't describe a way currently to run the guided setup
with a manual package install, remove that link altogether for the guided
setup page.

In passing, add an emphasis on guided setup only support Ubuntu/Debian.