### PR TITLE
Update RDS docs settings links to point to official docs

### DIFF
--- a/install/amazon_rds/_01_public.mdx
+++ b/install/amazon_rds/_01_public.mdx
@@ -31,9 +31,9 @@ Then set the following configuration parameters:
 
  Name | New Value | &nbsp;
  ---- | ------ | -------
- [pg\_stat\_statements.track](https://demo.pganalyze.com/databases/6/config/track_activity_query_size) | ALL | Optional, enables tracking of queries inside stored procedures
-[shared\_preload\_libraries](https://demo.pganalyze.com/databases/6/config/shared_preload_libraries) | pg\_stat\_statements
-[track\_activity\_query\_size](https://demo.pganalyze.com/databases/6/config/track_activity_query_size) | 2048
+ [pg\_stat\_statements.track](https://www.postgresql.org/docs/current/pgstatstatements.html#id-1.11.7.39.9) | ALL | Optional, enables tracking of queries inside stored procedures
+[shared\_preload\_libraries](https://www.postgresql.org/docs/current/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-PRELOAD) | pg\_stat\_statements
+[track\_activity\_query\_size](https://www.postgresql.org/docs/current/runtime-config-statistics.html#RUNTIME-CONFIG-STATISTICS-COLLECTOR) | 2048
 
 ---
 


### PR DESCRIPTION
Right now, these point to demo.pganalyze.com, but due to the
navigation changes from 64f2fda29f88f52e022fc27a9c7fd550063b0a6f and
follow up commits, these routes are not valid.

Since we've been de-emphasizing demo.pganalyze.com, point these to
the official Postgres docs rather than fixing the links.
