### PR TITLE
Add note about DEFAULT_ORG_ROLE to LDAP instructions

### DIFF
--- a/enterprise/setup/index.mdx
+++ b/enterprise/setup/index.mdx
@@ -282,9 +282,9 @@ AWS_REGION=us-east-1
 
 ### Appendix D - LDAP configuration
 
-If configuring LDAP after initially setting up an organization with standard password-based login,
-be sure to set DEFAULT_ORG_ROLE (see above) to ensure that new LDAP users are added to the existing
-organization.
+When using LDAP, it is recommended to also set DEFAULT_ORG_ROLE to a non-empty value (see above)
+to ensure that new LDAP users are added to the existing organization.
+
 
 * `LDAP_HOST`: Internal hostname or IP of your LDAP server
 * `LDAP_PORT`: Port of your LDAP server. Use port 636 for LDAPS

--- a/enterprise/setup/index.mdx
+++ b/enterprise/setup/index.mdx
@@ -282,6 +282,10 @@ AWS_REGION=us-east-1
 
 ### Appendix D - LDAP configuration
 
+If configuring LDAP after initially setting up an organization with standard password-based login,
+be sure to set DEFAULT_ORG_ROLE (see above) to ensure that new LDAP users are added to the existing
+organization.
+
 * `LDAP_HOST`: Internal hostname or IP of your LDAP server
 * `LDAP_PORT`: Port of your LDAP server. Use port 636 for LDAPS
 * `LDAP_BASE_DN`: Base DN that all lookups should be done with. You can use this to restrict access to a subset of your LDAP accounts


### PR DESCRIPTION
If one initially sets up an organization using a password-based login,
but then enables LDAP, the LDAP users will not be members of the
organization (and will not be able to create new organizations due to
Enterprise restrictions).

Include a note explaining this in the LDAP instructions.
