### PR TITLE
Add note about collector dyno sizing on Heroku

### DIFF
--- a/install/heroku_postgres/01_deploy_the_collector.mdx
+++ b/install/heroku_postgres/01_deploy_the_collector.mdx
@@ -55,6 +55,9 @@ After the app was created, configure it to use the **paid Hobby dyno** instead o
 
 <ImgPaidDyno />
 
+Note: if you have a large schema, a lot of query activity, or high log volume, you may need a larger dyno size.
+Check the Heroku dashboard to see if your collector dyno is swapping or crashing.
+
 Now you can continue by attaching your databases:
 
 <Link className="btn btn-success" to="02_attach_databases">


### PR DESCRIPTION
For a large or active Heroku database, a hobby dyno may not be enough.
This will show up as crashes and missing data in pganalyze, and it may
not be obvious the collector is under-resourced. We should note this
as a potential problem during onboarding.
