### PR TITLE
Document get_column_stats helper

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -12,6 +12,7 @@ const MonitoringUserSetupInstructions: React.FunctionComponent<Props> = ({
   minPostgres = 90200,
   password = 'mypassword'
 }) => {
+  const CodeBlock = useCodeBlock();
   type SetupOpt = [ id: string, version: number, label: string, instructions: React.ComponentType<{password: string}> ];
   const opts: SetupOpt[] = [
     [ 'monitoring_user_10', 100000, 'PostgreSQL 10+', MonitoringUser10 ],
@@ -21,12 +22,27 @@ const MonitoringUserSetupInstructions: React.FunctionComponent<Props> = ({
 
   const tabs = opts.map<TabItem>(opt => [opt[0], opt[2]])
   return (
-    <TabPanel items={tabs}>
-      {(idx: number) => {
-        const ActiveTab = opts[idx][3];
-        return <ActiveTab password={password} />
-      }}
-    </TabPanel>
+    <>
+      <TabPanel items={tabs}>
+        {(idx: number) => {
+          const ActiveTab = opts[idx][3];
+          return <ActiveTab password={password} />
+        }}
+      </TabPanel>
+      <p>
+        Then, connect to every database that you plan to monitor on this server and
+        run the following:
+      </p>
+      <CodeBlock>
+        {`CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
+$$
+  /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
+  n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
+  most_common_elem_freqs, elem_count_histogram
+  FROM pg_catalog.pg_stats;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
+      </CodeBlock>
+    </>
   );
 };
 

--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -30,7 +30,7 @@ const MonitoringUserSetupInstructions: React.FunctionComponent<Props> = ({
         }}
       </TabPanel>
       <p>
-        Then, connect to every database that you plan to monitor on this server and
+        Then, connect to each database that you plan to monitor on this server and
         run the following:
       </p>
       <CodeBlock>


### PR DESCRIPTION
Right now, this is only documented in the collector README and not as
part of normal setup. We've been trying to move installation
instructions out of the README to avoid maintaining them in multiple
places and to give users platform-specific onboarding documentation
where possible.

Because the instructions are shared across four platforms, they're a
little vague, but reviewing them in situ in each of the four guides, I
think they work.

We should also change the link in the collector warning once this is
live.
