### PR TITLE
Clarify references to API keys in-app

### DIFF
--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -48,8 +48,8 @@ Common settings for configuring collector behavior, independent of the platform.
       <td>n/a, required</td>
       <td>
         API key to authenticate the collector to the pganalyze app. We will show this
-        when adding a server in the app, and you can review it in your organization's
-        API keys page.
+        when adding a server in the app, and you can review it on your organization's
+        Settings page under the API keys tab.
       </td>
     </tr>
     <tr>

--- a/install/amazon_rds/05_configure_the_collector_docker.mdx
+++ b/install/amazon_rds/05_configure_the_collector_docker.mdx
@@ -28,7 +28,7 @@ DB_PASSWORD=your_monitoring_user_password`}
         ) : (
           <React.Fragment>
             You can find your <code>PGA_API_KEY</code> on your
-            organization&apos;s API keys page.
+            organization&apos;s Settings page under the API keys tab.
           </React.Fragment>
         )}
       </p>

--- a/install/amazon_rds/05_configure_the_collector_ec2.mdx
+++ b/install/amazon_rds/05_configure_the_collector_ec2.mdx
@@ -15,8 +15,8 @@ export const APIKeyInstructions = ({ apiKey }) => {
     </React.Fragment>
   ) : (
     <React.Fragment>
-      The <code>api_key</code> can be found in the pganalyze API keys page for
-      your organization
+      The <code>api_key</code> can be found on the pganalyze Settings page for
+      your organization under the API keys tab
     </React.Fragment>
   );
 };

--- a/install/amazon_rds/05_configure_the_collector_ecs.mdx
+++ b/install/amazon_rds/05_configure_the_collector_ecs.mdx
@@ -37,9 +37,9 @@ aws ssm put-parameter --name /pganalyze/PGA_API_KEY --type SecureString --value 
         ) : (
           <React.Fragment>
             Replace <code>YOUR_PGANALYZE_API_KEY</code> with the API key from
-            your organization&apos;s API keys page, and{" "}
-            <code>YOUR_DB_PASSWORD</code> with the monitoring user password for
-            your database.
+            your organization&apos;s Settings page (under the API Keys tab),
+            and <code>YOUR_DB_PASSWORD</code> with the monitoring user password
+            for your database.
           </React.Fragment>
         )}
       </p>

--- a/install/azure_database/03_configure_the_collector_docker.mdx
+++ b/install/azure_database/03_configure_the_collector_docker.mdx
@@ -15,8 +15,8 @@ export const APIKeyInstructions = ({ apiKey }) => {
     </React.Fragment>
   ) : (
     <React.Fragment>
-      The <code>PGA_API_KEY</code> can be found in the pganalyze API keys page
-      for your organization
+      The <code>PGA_API_KEY</code> can be found in the pganalyze Settings page
+      for your organization, under the API keys tab
     </React.Fragment>
   );
 };

--- a/install/azure_database/03_configure_the_collector_package.mdx
+++ b/install/azure_database/03_configure_the_collector_package.mdx
@@ -15,8 +15,8 @@ export const APIKeyInstructions = ({ apiKey }) => {
     </React.Fragment>
   ) : (
     <React.Fragment>
-      The <code>api_key</code> can be found in the pganalyze API keys page for
-      your organization
+      The <code>api_key</code> can be found in the pganalyze Settings page for
+      your organization, under the API keys tab
     </React.Fragment>
   );
 };

--- a/install/google_cloud_sql/03_configure_the_collector_docker.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector_docker.mdx
@@ -15,8 +15,8 @@ export const APIKeyInstructions = ({ apiKey }) => {
     </React.Fragment>
   ) : (
     <React.Fragment>
-      The <code>PGA_API_KEY</code> can be found in the pganalyze API keys page
-      for your organization
+      The <code>PGA_API_KEY</code> can be found in the pganalyze Settings page
+      for your organization, under the API keys tab
     </React.Fragment>
   );
 };

--- a/install/google_cloud_sql/03_configure_the_collector_package.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector_package.mdx
@@ -15,8 +15,8 @@ export const APIKeyInstructions = ({ apiKey }) => {
     </React.Fragment>
   ) : (
     <React.Fragment>
-      The <code>api_key</code> can be found in the pganalyze API keys page for
-      your organization
+      The <code>api_key</code> can be found in the pganalyze Settings page for
+      your organization, under the API keys tab
     </React.Fragment>
   );
 };

--- a/install/self_managed/04_configure_the_collector_docker.mdx
+++ b/install/self_managed/04_configure_the_collector_docker.mdx
@@ -15,8 +15,8 @@ export const APIKeyInstructions = ({ apiKey }) => {
     </React.Fragment>
   ) : (
     <React.Fragment>
-      The <code>PGA_API_KEY</code> can be found in the pganalyze API keys page
-      for your organization
+      The <code>PGA_API_KEY</code> can be found in the pganalyze Settings page
+      for your organization, under the API keys tab
     </React.Fragment>
   );
 };

--- a/install/self_managed/04_configure_the_collector_package.mdx
+++ b/install/self_managed/04_configure_the_collector_package.mdx
@@ -15,8 +15,8 @@ export const APIKeyInstructions = ({ apiKey }) => {
     </React.Fragment>
   ) : (
     <React.Fragment>
-      The <code>api_key</code> can be found in the pganalyze API keys page for
-      your organization
+      The <code>api_key</code> can be found in the pganalyze Settings page for
+      your organization, under the API keys tab
     </React.Fragment>
   );
 };


### PR DESCRIPTION
Currently, we talk about the API Keys page, but it may not be obvious
how to get there.

Describe the full navigation necessary to get to the API keys page
(Settings page, API keys tab) when referencing it.
