### PR TITLE
Fix escaping in helper function documentation

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -74,7 +74,7 @@ DECLARE
   prepared_params text;
   result text;
 BEGIN
-  SELECT regexp_replace(query, ';+\s*\Z', '') INTO prepared_query;
+  SELECT regexp_replace(query, ';+\\s*\\Z', '') INTO prepared_query;
   IF prepared_query LIKE '%;%' THEN
     RAISE EXCEPTION 'cannot run EXPLAIN when query contains semicolon';
   END IF;
@@ -123,7 +123,7 @@ $$
 DECLARE
   result text;
 BEGIN
-  IF log_filename !~ '\A[\w\.-]+\Z' THEN
+  IF log_filename !~ '\\A[\\w\\.-]+\\Z' THEN
     RAISE EXCEPTION 'invalid log filename';
   END IF;
 


### PR DESCRIPTION
In two places, we're using regular expressions with backslashes, but
because these are in TypeScript backtick-quoted strings, the
backslashes are interpreted as escapes for the following
characters. Escaped characters with no special meaning render as
themselves, but this means the backslashes are stripped.

Add additional backslashes to escape the backslashes we want to keep.
