### PR TITLE
Enterprise: Rework documentation, consistently use "Enterprise Server"

### DIFF
--- a/api/create-api-key.mdx
+++ b/api/create-api-key.mdx
@@ -68,9 +68,9 @@ The result will be a JSON document that looks like this:
 }
 ```
 
-## Creating a read-write API token (pganalyze Enterprise Edition)
+## Creating a read-write API token (pganalyze Enterprise Server)
 
-In order to create a read-write API token for use with pganalyze Enterprise Edition,
+In order to create a read-write API token for use with pganalyze Enterprise Server,
 make sure you run at least the [2019.04.1](/docs/enterprise/releases/2019-04-1) and then use the "Create Read-Write API Key" button.
 
 You should then see the new key marked as read-write in the UI:

--- a/api/index.mdx
+++ b/api/index.mdx
@@ -28,7 +28,7 @@ data. 2) Mutation endpoints, which are used to change (mutate) data.
     * [getIssues - Get check-up issues and alerts](/docs/api/queries/getIssues)
     * [getQueryStats - Export query statistics](/docs/api/queries/getQueryStats)
 - [Mutations](/docs/api/mutations)
-    * [addServer - Add a server to pganalyze Enterprise Edition](/docs/api/mutations/addServer)
+    * [addServer - Add a server to pganalyze Enterprise Server](/docs/api/mutations/addServer)
 
 ## Rate Limits
 

--- a/api/mutations/addServer.mdx
+++ b/api/mutations/addServer.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'addServer - Add a server to pganalyze Enterprise Edition'
+title: 'addServer - Add a server to pganalyze Enterprise Server'
 backlink_href: /docs/api/mutations
 backlink_title: 'pganalyze GraphQL API Mutations'
 ---
 
 ## Use case
 
-This API is only supported for pganalyze Enterprise Edition running on-premise, and is used to configure the pganalyze container for connecting to your database servers.
+This API is only supported for pganalyze Enterprise Server when utilizing the collector inside the central installation, and is used to configure the connections to your database servers.
 
 For registering new servers to the hosted service you can simply use an organization-wide collector key and follow the regular installation steps (no API call necessary).
 

--- a/api/mutations/index.mdx
+++ b/api/mutations/index.mdx
@@ -6,4 +6,4 @@ backlink_title: 'pganalyze GraphQL API'
 
 Officially available API mutation endpoints:
 
-* [addServer - Add a server to pganalyze Enterprise Edition](/docs/api/mutations/addServer)
+* [addServer - Add a server to pganalyze Enterprise Server](/docs/api/mutations/addServer)

--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -57,7 +57,7 @@ Common settings for configuring collector behavior, independent of the platform.
       <td>https://api.pganalyze.com</td>
       <td>
         Base URL for contacting the pganalyze API. You typically do not need to change this, unless you are
-        running <a href="/docs/enterprise">pganalyze Enterprise Edition</a>.
+        running <a href="/docs/enterprise">pganalyze Enterprise Server</a>.
       </td>
     </tr>
     {/*

--- a/directory.json
+++ b/directory.json
@@ -37,7 +37,7 @@
       "path": "/docs/api/mutations"
     },
     "api/mutations/addServer": {
-      "title": "addServer - Add a server to pganalyze Enterprise Edition",
+      "title": "addServer - Add a server to pganalyze Enterprise Server",
       "path": "/docs/api/mutations/addServer"
     },
     "api/queries": {
@@ -73,31 +73,27 @@
       "path": "/docs/collector/settings"
     },
     "enterprise": {
-      "title": "pganalyze Enterprise Edition",
+      "title": "pganalyze Enterprise Server",
       "path": "/docs/enterprise"
     },
+    "enterprise/architecture": {
+      "title": "Enterprise Server: Reference Architecture",
+      "path": "/docs/enterprise/architecture"
+    },
     "enterprise/google-auth": {
-      "title": "Enterprise Edition: How to setup Google Auth Integration",
+      "title": "Enterprise Server: How to setup Google Auth Integration",
       "path": "/docs/enterprise/google-auth"
     },
     "enterprise/integrations": {
-      "title": "Enterprise Edition: How to Set Up Slack and PagerDuty Integration",
+      "title": "Enterprise Server: How to Set Up Slack and PagerDuty Integration",
       "path": "/docs/enterprise/integrations"
     },
     "enterprise/log-insights": {
       "title": "Enterprise Edition: Log Insights Setup",
       "path": "/docs/enterprise/log-insights"
     },
-    "enterprise/log-insights-local": {
-      "title": "Enterprise Edition: Log Insights Setup (Local Storage)",
-      "path": "/docs/enterprise/log-insights-local"
-    },
-    "enterprise/log-insights-s3": {
-      "title": "Enterprise Edition: Log Insights Setup (Amazon S3)",
-      "path": "/docs/enterprise/log-insights-s3"
-    },
     "enterprise/releases": {
-      "title": "Enterprise Edition: Release Changelog",
+      "title": "Enterprise Server: Release Changelog",
       "path": "/docs/enterprise/releases"
     },
     "enterprise/releases/2017-08-0": {
@@ -205,19 +201,35 @@
       "path": "/docs/enterprise/releases/2022-05-1"
     },
     "enterprise/setup": {
-      "title": "Enterprise Edition: Initial Setup",
+      "title": "Enterprise Server: Initial Setup",
       "path": "/docs/enterprise/setup"
     },
     "enterprise/setup/kubernetes_amazon_eks": {
-      "title": "Enterprise Edition: Initial Setup (Kubernetes on Amazon EKS)",
+      "title": "Enterprise Server: Initial Setup (Kubernetes on Amazon EKS)",
       "path": "/docs/enterprise/setup/kubernetes_amazon_eks"
     },
+    "enterprise/setup/object-storage": {
+      "title": "Enterprise Server: Object Storage Setup",
+      "path": "/docs/enterprise/setup/object-storage"
+    },
+    "enterprise/setup/object-storage-local": {
+      "title": "Enterprise Server: Object Storage Setup (Local Storage)",
+      "path": "/docs/enterprise/setup/object-storage-local"
+    },
+    "enterprise/setup/object-storage-s3": {
+      "title": "Enterprise Server: Object Storage Setup (Amazon S3)",
+      "path": "/docs/enterprise/setup/object-storage-s3"
+    },
+    "enterprise/setup/separate-collector-install": {
+      "title": "Enterprise Server: Separate collector installation",
+      "path": "/docs/enterprise/setup/separate-collector-install"
+    },
     "enterprise/troubleshooting": {
-      "title": "Enterprise Edition: Troubleshooting",
+      "title": "Enterprise Server: Troubleshooting",
       "path": "/docs/enterprise/troubleshooting"
     },
     "enterprise/upgrade": {
-      "title": "Enterprise Edition: Upgrading to new releases",
+      "title": "Enterprise Server: Upgrading to new releases",
       "path": "/docs/enterprise/upgrade"
     },
     "explain": {

--- a/enterprise/architecture.mdx
+++ b/enterprise/architecture.mdx
@@ -1,0 +1,11 @@
+---
+title: 'Enterprise Server: Reference Architecture'
+backlink_href: /docs/enterprise
+backlink_title: 'pganalyze Enterprise Server'
+---
+
+Here you can see the reference architecture for a scaled out version of pganalyze Enterprise Server. This diagram also illustrates how data gets sent between different components.
+
+This is focused on a deployment for monitoring Amazon RDS or Aurora, [deployed using Amazon EKS](/docs/enterprise/setup/kubernetes_amazon_eks) and intended for larger setups that [run the collector separately](/docs/enterprise/setup/separate-collector-install), with a separation between the central AWS account and the application AWS accounts.
+
+![Reference architecture diagram](architecture.svg)

--- a/enterprise/architecture.svg
+++ b/enterprise/architecture.svg
@@ -1,0 +1,512 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" version="1.1" xmlns:xl="http://www.w3.org/1999/xlink" viewBox="88.96868 -535.96167 1434.0313 1492.4617" width="1434.0313" height="1492.4617">
+  <defs>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="#d5362c">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="#336792">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_4" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="#a5a5a5">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_5" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="Canvas_1" fill="none" stroke="none" stroke-dasharray="none" stroke-opacity="1" fill-opacity="1">
+    <title>Canvas 1</title>
+    <rect fill="white" x="88.96868" y="-535.96167" width="1434.0313" height="1492.4617"/>
+    <g id="Canvas_1_Layer_1">
+      <title>Layer 1</title>
+      <g id="Graphic_130">
+        <path d="M 139.46868 -485.46167 L 897 -485.46167 L 897 54 L 139.46868 54 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="4.0,4.0" stroke-width="1"/>
+        <text transform="translate(149.46868 -475.46167)" fill="black">
+          <tspan font-family="Avenir Next" font-weight="bold" font-size="16" fill="black" x="0" y="16">Application AWS Account</tspan>
+        </text>
+      </g>
+      <g id="Graphic_20">
+        <path d="M 139.46868 209.10827 L 1168.4687 209.10827 L 1168.4687 906 L 139.46868 906 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="4.0,4.0" stroke-width="1"/>
+        <text transform="translate(149.46868 219.10827)" fill="black">
+          <tspan font-family="Avenir Next" font-weight="bold" font-size="16" fill="black" x="0" y="16">Internal AWS Account</tspan>
+        </text>
+      </g>
+      <g id="Graphic_129">
+        <rect x="146.95439" y="507" width="1005.0456" height="151.5" fill="white"/>
+        <rect x="146.95439" y="507" width="1005.0456" height="151.5" stroke="#a5a5a5" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(156.95439 517)" fill="black">
+          <tspan font-family="Helvetica Neue" font-weight="bold" font-size="16" fill="black" x="0" y="16">Internal EKS</tspan>
+        </text>
+      </g>
+      <g id="Graphic_102">
+        <rect x="954.25" y="533.58333" width="181" height="108" fill="white"/>
+        <rect x="954.25" y="533.58333" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(959.25 554.58333)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="48.14" y="16">pganalyze</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="43.012" y="38">Web Server</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="66.268" y="60">(app)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_101">
+        <rect x="661.02104" y="533.8169" width="181" height="108" fill="white"/>
+        <rect x="661.02104" y="533.8169" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(666.02104 554.8169)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="16.036" y="16">pganalyze Workers</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="8.628" y="38">(Statistics Processing, </tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="18.532" y="60">Index Advisor, etc)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_100">
+        <rect x="371.5533" y="533.8169" width="181" height="108" fill="white"/>
+        <rect x="371.5533" y="533.8169" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(376.5533 554.8169)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="48.14" y="16">pganalyze</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="47.852" y="38">API Server</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="69.348" y="60">(api)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_28">
+        <rect x="382.5143" y="-441" width="228.66315" height="456" fill="white"/>
+        <rect x="382.5143" y="-441" width="228.66315" height="456" stroke="#a5a5a5" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(392.5143 -431)" fill="black">
+          <tspan font-family="Avenir Next" font-weight="bold" font-size="16" fill="black" x="0" y="16">Application EKS</tspan>
+        </text>
+      </g>
+      <g id="Graphic_2">
+        <rect x="950" y="528" width="181" height="108" fill="#afabbe"/>
+        <rect x="950" y="528" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(955 549)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="48.14" y="16">pganalyze</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="22.708" y="38">Enterprise Server</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="40.572" y="60">(App server)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_3">
+        <rect x="366" y="528" width="181" height="108" fill="#afabbe"/>
+        <rect x="366" y="528" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(371 549)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="48.14" y="16">pganalyze</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="22.708" y="38">Enterprise Server</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="44.012" y="60">(API server)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_4">
+        <rect x="719.6667" y="251.5" width="181" height="108" fill="#bfd989"/>
+        <rect x="719.6667" y="251.5" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(724.6667 283.5)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="49.564" y="16">S3 Bucket</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="63.268" y="38">(Logs)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_5">
+        <rect x="489.33333" y="251.5" width="181" height="108" fill="#bfd989"/>
+        <rect x="489.33333" y="251.5" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(494.33333 283.5)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="49.564" y="16">S3 Bucket</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="42.996" y="38">(Snapshots)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_6">
+        <rect x="259" y="769.5345" width="181" height="108" fill="#bfd989"/>
+        <rect x="259" y="769.5345" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(264 790.5345)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="15.34" y="16">Elastic Cache Redis</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="16.124" y="38">(Internal Queue for </tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="45.74" y="60">pganalyze)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_7">
+        <rect x="719.6667" y="770.1869" width="181" height="108" fill="#bfd989"/>
+        <rect x="719.6667" y="770.1869" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(724.6667 791.1869)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="4.868" y="16">RDS Postgres Instance</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="30.172" y="38">(Internal DB for </tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="45.74" y="60">pganalyze)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_9">
+        <rect x="401.5143" y="-115" width="181" height="108" fill="#afabbe"/>
+        <rect x="401.5143" y="-115" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(406.5143 -83)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="48.14" y="16">pganalyze</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="53.7" y="38">collector</tspan>
+        </text>
+      </g>
+      <g id="Graphic_12">
+        <rect x="159.46868" y="-441" width="181" height="108" fill="#acdfdf"/>
+        <rect x="159.46868" y="-441" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(164.46868 -409)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="4.868" y="16">RDS Postgres Instance</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="26.676" y="38">(for Application)</tspan>
+        </text>
+      </g>
+      <g id="Line_14">
+        <path d="M 446.7643 -7 L 446.7643 227.98438 L 349.5 227.98438 L 349.5 241.6" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_15">
+        <rect x="656.1877" y="528" width="181" height="108" fill="#afabbe"/>
+        <rect x="656.1877" y="528" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(661.1877 549)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="48.14" y="16">pganalyze</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="22.708" y="38">Enterprise Server</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="50.5" y="60">(Workers)</tspan>
+        </text>
+      </g>
+      <g id="Line_16">
+        <path d="M 402.2 636 L 402.2 681.0833 L 349.5 681.0833 L 349.5 759.6345" marker-end="url(#FilledArrow_Marker_2)" stroke="#d5362c" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_21">
+        <rect x="950" y="769.5345" width="181" height="108" fill="#bfd989"/>
+        <rect x="950" y="769.5345" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(955 790.5345)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="23.268" y="16">Application Load </tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="53.748" y="38">Balancer</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="64.94" y="60">(App)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_27"/>
+      <g id="Graphic_29"/>
+      <g id="Line_38">
+        <path d="M 492.0143 -7 L 492.0143 126.85417 L 579.8333 126.85417 L 579.8333 241.6" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_42">
+        <rect x="400.8683" y="171.58854" width="91.792" height="32" fill="white"/>
+        <text transform="translate(405.8683 176.58854)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+      <g id="Graphic_43">
+        <rect x="533.93733" y="172.50548" width="91.792" height="32" fill="white"/>
+        <text transform="translate(538.93733 177.50548)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+      <g id="Graphic_45">
+        <rect x="158.46868" y="-192.1308" width="181" height="108" fill="#acdedd"/>
+        <rect x="158.46868" y="-192.1308" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(163.46868 -160.1308)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="53.532" y="16">AWS API</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="16.212" y="38">(RDS, CloudWatch)</tspan>
+        </text>
+      </g>
+      <g id="Line_47">
+        <path d="M 446.7643 -115 L 446.7643 -212.14736 L 307.84762 -212.14736 L 307.84762 -299.33333 L 295.21868 -299.33333 L 295.21868 -323.1" marker-end="url(#FilledArrow_Marker_3)" stroke="#336792" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_48">
+        <rect x="250.36762" y="-312.20485" width="114.96" height="32" fill="white"/>
+        <text transform="translate(255.36762 -307.20485)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="0" y="16">Postgres/5432</tspan>
+        </text>
+      </g>
+      <g id="Line_49">
+        <path d="M 401.5143 -61 L 248.96868 -61 L 248.96868 -74.2308" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_50">
+        <rect x="258.3737" y="-77" width="91.792" height="32" fill="white"/>
+        <text transform="translate(263.3737 -72)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+      <g id="Line_57">
+        <path d="M 474.6 528 L 474.6 425.5729 L 579.8333 425.5729 L 579.8333 369.4" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_58">
+        <path d="M 995.25 636 L 995.25 681.0208 L 349.5 681.0208 L 349.5 759.6345" marker-end="url(#FilledArrow_Marker_2)" stroke="#d5362c" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_61">
+        <path d="M 537.2643 -7 L 537.2643 86.40625 L 810.1667 86.40625 L 810.1667 241.6" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_62">
+        <path d="M 1040.5 636 L 1040.5 715.9541 L 810.1667 715.9541 L 810.1667 760.2869" marker-end="url(#FilledArrow_Marker_3)" stroke="#336792" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_63">
+        <path d="M 701.4377 528 L 701.4377 425.97917 L 579.8333 425.97917 L 579.8333 369.4" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_64">
+        <rect x="259" y="251.5" width="181" height="108" fill="#bfd989"/>
+        <rect x="259" y="251.5" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(264 272.5)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="23.268" y="16">Application Load </tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="53.748" y="38">Balancer</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="68.38" y="60">(API)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_65">
+        <rect x="764.2707" y="170.72697" width="91.792" height="32" fill="white"/>
+        <text transform="translate(769.2707 175.72697)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+      <g id="Line_66">
+        <path d="M 349.5 359.5 L 349.5 443.75 L 402.2 443.75 L 402.2 518.1" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_68">
+        <rect x="330.7215" y="427.75" width="92.048" height="32" fill="white"/>
+        <text transform="translate(335.7215 432.75)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="0" y="16">HTTP/5000</tspan>
+        </text>
+      </g>
+      <g id="Line_70">
+        <path d="M 1040.5 769.5345 L 1040.5 747.5417 L 1085.75 747.5417 L 1085.75 645.9" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_71">
+        <rect x="1039.726" y="722.2879" width="92.048" height="32" fill="white"/>
+        <text transform="translate(1044.726 727.2879)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="0" y="16">HTTP/5000</tspan>
+        </text>
+      </g>
+      <g id="Graphic_72">
+        <rect x="1245" y="769.5345" width="181" height="108" fill="white"/>
+        <rect x="1245" y="769.5345" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(1250 801.5345)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="52.332" y="16">End User</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6.972" y="38">(e.g. DBA, developer)</tspan>
+        </text>
+      </g>
+      <g id="Line_73">
+        <line x1="1245" y1="823.5345" x2="1140.9" y2="823.5345" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_76">
+        <rect x="533.93733" y="377.595" width="91.792" height="32" fill="white"/>
+        <text transform="translate(538.93733 382.595)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+      <g id="Line_77">
+        <path d="M 746.6877 636 L 746.6877 681.1406 L 349.5 681.1406 L 349.5 759.6345" marker-end="url(#FilledArrow_Marker_2)" stroke="#d5362c" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_80">
+        <rect x="303.06" y="723.8461" width="92.88" height="32" fill="white"/>
+        <text transform="translate(308.06 728.8461)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="5115908e-19" y="16">Redis/6379</tspan>
+        </text>
+      </g>
+      <g id="Graphic_81">
+        <rect x="1152.2242" y="807.5345" width="91.792" height="32" fill="white"/>
+        <text transform="translate(1157.2242 812.5345)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+      <g id="Line_87">
+        <path d="M 995.25 528 L 995.25 456.30713 L 810.1667 456.30713 L 810.1667 369.4" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_92">
+        <text transform="translate(627.0627 -110)" fill="black">
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="16">Each collector can monitor</tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="38">one or more RDS instances</tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="82">Collector can filter sensitive data</tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="104">(query parameters, log events, ..)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_94">
+        <text transform="translate(164.46868 -319.22327)" fill="black">
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="16">Postgres is </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="38">accessed</tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="60">using restricted </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="82">monitoring user</tspan>
+        </text>
+      </g>
+      <g id="Graphic_95">
+        <text transform="translate(171.95439 -45.038333)" fill="black">
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="16">Instance role with</tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="38">IAM policy that allows </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="60">RDS log download</tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="82">and system metrics</tspan>
+        </text>
+      </g>
+      <g id="Line_96">
+        <path d="M 791.9377 636 L 791.9377 675.5208 C 797.4377 675.5208 797.4377 686.5208 791.9377 686.5208 L 791.9377 715.8867 L 810.1667 715.8867 L 810.1667 750.3869" marker-end="url(#FilledArrow_Marker_3)" stroke="#336792" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_98">
+        <rect x="401.5143" y="-368.7977" width="181" height="108" fill="white"/>
+        <rect x="401.5143" y="-368.7977" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(406.5143 -336.7977)" fill="#a5a5a5">
+          <tspan font-family="Avenir Next" font-size="16" fill="#a5a5a5" x="57.1" y="16">Existing</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="#a5a5a5" x="43.46" y="38">Application</tspan>
+        </text>
+      </g>
+      <g id="Line_99">
+        <path d="M 401.5143 -314.79768 L 370.9915 -314.79768 L 370.9915 -387 L 350.3687 -387" marker-end="url(#FilledArrow_Marker_4)" stroke="#a5a5a5" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_103">
+        <rect x="489.33333" y="769.5345" width="181" height="108" fill="#bfd989"/>
+        <rect x="489.33333" y="769.5345" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(494.33333 790.5345)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="39.732" y="16">Amazon SES</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="25.476" y="38">(For alert emails,</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="29.828" y="60">weekly reports)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_106">
+        <text transform="translate(599 98.55414)" fill="black">
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="16">S3 bucket access is granted </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="38">to collector via short-lived </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="60">upload-only credentials</tspan>
+        </text>
+      </g>
+      <g id="Graphic_108">
+        <text transform="translate(202 124.9375)" fill="black">
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="16">pganalyze API server access is </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="38">authenticated using special</tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="60">collector API keys</tspan>
+        </text>
+      </g>
+      <g id="Graphic_109">
+        <rect x="1245" y="590.75445" width="181" height="108" fill="#acdfdf"/>
+        <rect x="1245" y="590.75445" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(1250 622.75445)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="7.82" y="16">External SAML-based </tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="37.34" y="38">SSO Provider</tspan>
+        </text>
+      </g>
+      <g id="Line_111">
+        <line x1="1335.5" y1="769.5345" x2="1335.5" y2="708.65445" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_112">
+        <text transform="translate(1231 517.75445)" fill="black">
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="16">pganalyze can be configured to </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="38">accept SAML-based logins</tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="60">(e.g. to integrate with Okta, etc)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_114">
+        <rect x="1289.604" y="728.1418" width="91.792" height="32" fill="white"/>
+        <text transform="translate(1294.604 733.1418)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+      <g id="Graphic_115">
+        <rect x="950" y="-413.7977" width="30" height="30" fill="#b1acbf"/>
+        <rect x="950" y="-413.7977" width="30" height="30" stroke="#797979" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_116">
+        <text transform="translate(955 -466)" fill="black">
+          <tspan font-family="Avenir Next" font-weight="bold" font-size="20" fill="black" x="0" y="20">Legend</tspan>
+        </text>
+      </g>
+      <g id="Graphic_117">
+        <text transform="translate(997.5 -408.7977)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">New component provided by pganalyze Enterprise Server</tspan>
+        </text>
+      </g>
+      <g id="Graphic_119">
+        <rect x="950" y="-363.59536" width="30" height="30" fill="#bfd989"/>
+        <rect x="950" y="-363.59536" width="30" height="30" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_118">
+        <text transform="translate(997.5 -358.59536)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">New cloud resource provisioned for pganalyze Enterprise Server</tspan>
+        </text>
+      </g>
+      <g id="Graphic_121">
+        <rect x="950" y="-313.39304" width="30" height="30" fill="#acdfdf"/>
+        <rect x="950" y="-313.39304" width="30" height="30" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_120">
+        <text transform="translate(997.5 -308.39304)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Existing application / infrastructure component</tspan>
+        </text>
+      </g>
+      <g id="Graphic_122">
+        <text transform="translate(165.9172 538.58333)" fill="black">
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="16">The pganalyze Enterprise </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="38">Server container image </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="60">has different commands </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="82">for each component </tspan>
+          <tspan font-family="Avenir Next" font-style="italic" font-size="16" fill="black" x="0" y="104">that’s deployed</tspan>
+        </text>
+      </g>
+      <g id="Line_59">
+        <path d="M 438.4 528 L 438.4 456.3854 L 469.1 456.3854 C 469.1 450.8854 480.1 450.8854 480.1 456.3854 L 695.9377 456.3854 C 695.9377 450.8854 706.9377 450.8854 706.9377 456.3854 L 810.1667 456.3854 L 810.1667 379.3" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_60">
+        <path d="M 746.6877 528 L 746.6877 456.3032 L 810.1667 456.3032 L 810.1667 369.4" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_39">
+        <path d="M 510.8 636 L 510.8 675.5208 C 516.3 675.5208 516.3 686.6406 510.8 686.6406 L 510.8 715.9583 L 810.1667 715.9583 L 810.1667 750.3869" marker-end="url(#FilledArrow_Marker_3)" stroke="#336792" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_97">
+        <rect x="752.6867" y="722.375" width="114.96" height="32" fill="white"/>
+        <text transform="translate(757.6867 727.375)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="0" y="16">Postgres/5432</tspan>
+        </text>
+      </g>
+      <g id="Line_123">
+        <path d="M 958.5 -194.79768 L 975.4219 -194.79768 L 975.4219 -169.46435 L 962.5667 -169.46435" marker-end="url(#FilledArrow_Marker_2)" stroke="#d5362c" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_124">
+        <text transform="translate(1000.5443 -191.35501)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Redis protocol connection</tspan>
+        </text>
+      </g>
+      <g id="Line_126">
+        <path d="M 958.5 -252.8225 L 975.4219 -252.8225 L 975.4219 -227.48916 L 962.5667 -227.48916" marker-end="url(#FilledArrow_Marker_3)" stroke="#336792" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_125">
+        <text transform="translate(1000.5443 -249.37983)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Postgres protocol connection</tspan>
+        </text>
+      </g>
+      <g id="Graphic_88">
+        <rect x="764.2707" y="378.4944" width="91.792" height="32" fill="white"/>
+        <text transform="translate(769.2707 383.4944)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+      <g id="Line_128">
+        <path d="M 958.5 -136.77287 L 975.4219 -136.77287 L 975.4219 -111.43953 L 962.5667 -111.43953" marker-end="url(#FilledArrow_Marker_5)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_127">
+        <text transform="translate(1000.5443 -133.3302)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Other connections (HTTP, etc.)</tspan>
+        </text>
+      </g>
+      <g id="Line_104">
+        <path d="M 701.4377 636 L 701.4377 675.5208 C 706.9377 675.5208 706.9377 686.6406 701.4377 686.6406 L 701.4377 710.4583 C 706.9377 710.4583 706.9377 721.4583 701.4377 721.4583 L 701.4377 740.082 L 579.8333 740.082 L 579.8333 749.7345" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_105">
+        <rect x="537.15333" y="722.2879" width="85.36" height="32" fill="white"/>
+        <text transform="translate(542.15333 727.2879)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="29842795e-20" y="16">SMTP/587</tspan>
+        </text>
+      </g>
+      <g id="Graphic_131">
+        <rect x="950" y="251.5" width="181" height="108" fill="#bfd989"/>
+        <rect x="950" y="251.5" width="181" height="108" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(955 283.5)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="36.868" y="16">Amazon KMS</tspan>
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="13.7" y="38">(For log encryption)</tspan>
+        </text>
+      </g>
+      <g id="Line_132">
+        <path d="M 791.9377 528 L 791.9377 487.2969 L 989.75 487.2969 C 989.75 481.7969 1000.75 481.7969 1000.75 487.2969 L 1040.5 487.2969 L 1040.5 359.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_133">
+        <line x1="1040.5" y1="528" x2="1040.5" y2="369.4" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_135">
+        <path d="M 510.8 528 L 510.8 487.09375 L 695.9377 487.09375 C 695.9377 481.59375 706.9377 481.59375 706.9377 487.09375 L 741.1877 487.09375 C 741.1877 481.59375 752.1877 481.59375 752.1877 487.09375 L 989.75 487.09375 C 989.75 481.59375 1000.75 481.59375 1000.75 487.09375 L 1040.5 487.09375 L 1040.5 359.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_134">
+        <rect x="994.604" y="378.66107" width="91.792" height="32" fill="white"/>
+        <text transform="translate(999.604 383.66107)" fill="black">
+          <tspan font-family="Avenir Next" font-size="16" fill="black" x="6394885e-19" y="16">HTTPS/443</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/enterprise/google-auth.mdx
+++ b/enterprise/google-auth.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Enterprise Edition: How to setup Google Auth Integration'
+title: 'Enterprise Server: How to setup Google Auth Integration'
 backlink_href: /docs/enterprise
-backlink_title: 'pganalyze Enterprise Edition'
+backlink_title: 'pganalyze Enterprise Server'
 ---
 
 1. Create a new project in the Google Cloud Platform developer console

--- a/enterprise/index.mdx
+++ b/enterprise/index.mdx
@@ -1,22 +1,30 @@
 ---
-title: 'pganalyze Enterprise Edition'
+title: 'pganalyze Enterprise Server'
 backlink_href: /docs
 backlink_title: 'Documentation'
 ---
 
-We provide a local appliance for environments that store sensitive data
-(e.g. medical data or financial services) and can't use our hosted version.
+pganalyze Enterprise Server is a fully self-contained version of pganalyze that runs
+behind your firewall. We recommend using this deploy for storing highly sensitive data
+(e.g. medical data or financial services), or other situations where our cloud-based version is not a good fit.
 
-If you'd like to get a quote for a setup in your environment,
-**[please email us](mailto:support@pganalyze.com%3Fsubject%3DLocal%20Installation)**.
+If you'd like to start a trial of pganalyze Enterprise Server in your environment,
+**[please contact us](/contact)**.
+
+## Setup instructions
 
 - [Initial Setup on a VM](/docs/enterprise/setup)
 - [Initial Setup on Kubernetes (Amazon EKS)](/docs/enterprise/setup/kubernetes_amazon_eks)
-- [Release Changelog](/docs/enterprise/releases)
-- [Log Insights Setup](/docs/enterprise/log-insights)
-  - [Local Storage using Minio](/docs/enterprise/log-insights-local)
-  - [Cloud Storage using Amazon S3](/docs/enterprise/log-insights-s3)
+- [Object Storage Setup](/docs/enterprise/setup/object-storage)
+  - [Local Storage using Minio](/docs/enterprise/setup/object-storage-local)
+  - [Cloud Storage using Amazon S3](/docs/enterprise/setup/object-storage-s3)
+- [Separate collector installation](/docs/enterprise/setup/separate-collector-install)
 - [Google Auth Setup](/docs/enterprise/google-auth)
 - [PagerDuty and Slack Integration Setup](/docs/enterprise/integrations)
+
+## Other information
+
+- [Release Changelog](/docs/enterprise/releases)
 - [Upgrading to new releases](/docs/enterprise/upgrade)
+- [Reference Architecture](/docs/enterprise/architecture)
 - [Troubleshooting](/docs/enterprise/troubleshooting)

--- a/enterprise/integrations.mdx
+++ b/enterprise/integrations.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'Enterprise Edition: How to Set Up Slack and PagerDuty Integration'
+title: 'Enterprise Server: How to Set Up Slack and PagerDuty Integration'
 backlink_href: /docs/enterprise
-backlink_title: 'pganalyze Enterprise Edition'
+backlink_title: 'pganalyze Enterprise Server'
 ---
 
 In order to provide notifications about issues discovered in your database,
 pganalyze provides support for integrating with [Slack](https://slack.com/) or
 [PagerDuty](https://www.pagerduty.com). These integrations require additional
-setup for pganalyze Enterprise Edition.
+setup for pganalyze Enterprise Server.
 
 
 ## Slack

--- a/enterprise/releases/2017-08-0.mdx
+++ b/enterprise/releases/2017-08-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2017.08.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2017.08.0`

--- a/enterprise/releases/2017-10-0.mdx
+++ b/enterprise/releases/2017-10-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2017.10.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2017.10.0`
@@ -10,7 +10,7 @@ backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
 
 - Authenticate with Google Apps
   - As an option, users can now authenticate with Google Apps when logging into
-    a pganalyze Enterprise Edition instance, see [documentation](/docs/enterprise/google-auth)
+    a pganalyze Enterprise Server instance, see [documentation](/docs/enterprise/google-auth)
 - Introduce new check-up and alert configuration system
   - Make minimum calls for query slowness check configurable
 - Log Insights: Query sample collection

--- a/enterprise/releases/2017-11-0.mdx
+++ b/enterprise/releases/2017-11-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2017.11.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2017.11.0`

--- a/enterprise/releases/2017-12-0.mdx
+++ b/enterprise/releases/2017-12-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2017.12.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2017.12.0`

--- a/enterprise/releases/2018-02-0.mdx
+++ b/enterprise/releases/2018-02-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.02.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.02.0`

--- a/enterprise/releases/2018-02-1.mdx
+++ b/enterprise/releases/2018-02-1.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.02.1 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.02.1`

--- a/enterprise/releases/2018-02-2.mdx
+++ b/enterprise/releases/2018-02-2.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.02.2 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.02.2`

--- a/enterprise/releases/2018-02-3.mdx
+++ b/enterprise/releases/2018-02-3.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.02.3 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.02.3`

--- a/enterprise/releases/2018-02-4.mdx
+++ b/enterprise/releases/2018-02-4.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.02.4 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.02.4`

--- a/enterprise/releases/2018-07-0.mdx
+++ b/enterprise/releases/2018-07-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.07.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.07.0`
@@ -14,7 +14,7 @@ backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
       - We've added a new "Jump to Time" selector, as well as other UI elements to
         allow easy navigation to historic log data, up to 30 days into the past
   - Official support for on-premise systems, Amazon RDS, Amazon Aurora and Heroku Postgres
-      - See [documentation](/docs/enterprise/log-insights) for details how to set things up
+      - See [documentation](/docs/enterprise) for details how to set things up
   - Additional log classifications
   - Log Insights Checkpoint Analysis: Add support for 9.3 and 9.4
 - Once-per-minute query statistics (instead of every 10 minutes)

--- a/enterprise/releases/2018-08-0.mdx
+++ b/enterprise/releases/2018-08-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.08.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.08.0`

--- a/enterprise/releases/2018-08-1.mdx
+++ b/enterprise/releases/2018-08-1.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.08.1 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.08.1`
@@ -15,7 +15,7 @@ n/a
 
 - Fixes `rake db:setup` for initial setup on Postgres 9.6 and older
 - Disables high frequency query statistics collection when more than 5 servers are configured
-  - This caused issues due to the collector currently running serially for Enterprise Edition,
+  - This caused issues due to the collector currently running serially for Enterprise Server,
     we are working on introducing parallelism here, and will re-enable this feature once
     parallel statistics collection is available
 - Fix query statistics `collected_interval_secs` for full snapshot with historic stats

--- a/enterprise/releases/2018-08-2.mdx
+++ b/enterprise/releases/2018-08-2.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.08.2 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.08.2`

--- a/enterprise/releases/2018-09-0.mdx
+++ b/enterprise/releases/2018-09-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2018.09.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2018.09.0`
@@ -10,7 +10,7 @@ backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
 
 * Adds support for Postgres 11
 * Automated EXPLAIN plan collection through [auto_explain](https://www.postgresql.org/docs/10/static/auto-explain.html) (requires Log Insights)
-* Support for fully on-premise Log Insights setup (see [setup guide](/docs/enterprise/log-insights-local))
+* Support for fully on-premise Log Insights setup (see [setup guide](/docs/enterprise))
   * Previously we required log files and snapshots to be stored in an Amazon S3
     bucket, which doesn't always work, especially not when there are strict
     requirements for no data to leave an on-premise data center

--- a/enterprise/releases/2019-04-0.mdx
+++ b/enterprise/releases/2019-04-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2019.04.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2019.04.0`

--- a/enterprise/releases/2019-04-1.mdx
+++ b/enterprise/releases/2019-04-1.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2019.04.1 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2019.04.1`

--- a/enterprise/releases/2020-07-0.mdx
+++ b/enterprise/releases/2020-07-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2020.07.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2020.07.0`
@@ -45,7 +45,7 @@ backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
   - Fix Checkpoint Starting and Temp File Created bucketing for larger timeframes
   - Fix visualization bugs for Z00 classification of unknown log lines
   - Connection tracing: Fix connection logs for cases where the `log_line_prefix` is missing %d
-* Internal Enterprise Edition logging
+* Internal Enterprise Server logging
   - Always output webserver logs to stdout, and hide request_id to make logs easier to read
   - Don't run collector in verbose mode
 * Verify `MAILER_URL` setting when doing self-check

--- a/enterprise/releases/2020-07-1.mdx
+++ b/enterprise/releases/2020-07-1.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2020.07.1 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2020.07.1`

--- a/enterprise/releases/2020-07-2.mdx
+++ b/enterprise/releases/2020-07-2.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2020.07.2 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2020.07.2`

--- a/enterprise/releases/2020-09-0.mdx
+++ b/enterprise/releases/2020-09-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2020.09.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2020.09.0`

--- a/enterprise/releases/2021-02-0.mdx
+++ b/enterprise/releases/2021-02-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2021.02.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2021.02.0`

--- a/enterprise/releases/2021-06-0.mdx
+++ b/enterprise/releases/2021-06-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2021.06.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2021.06.0`

--- a/enterprise/releases/2021-12-0.mdx
+++ b/enterprise/releases/2021-12-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2021.12.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2021.12.0`

--- a/enterprise/releases/2021-12-1.mdx
+++ b/enterprise/releases/2021-12-1.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2021.12.1 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2021.12.1`

--- a/enterprise/releases/2022-05-0.mdx
+++ b/enterprise/releases/2022-05-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2022.05.0 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2022.05.0`

--- a/enterprise/releases/2022-05-1.mdx
+++ b/enterprise/releases/2022-05-1.mdx
@@ -1,7 +1,7 @@
 ---
 title: '2022.05.1 Release'
 backlink_href: /docs/enterprise/releases
-backlink_title: 'pganalyze Enterprise Edition: Release Changelog'
+backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 ---
 
 **Docker tag:** `quay.io/pganalyze/enterprise:v2022.05.1`

--- a/enterprise/releases/index.mdx
+++ b/enterprise/releases/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Enterprise Edition: Release Changelog'
+title: 'Enterprise Server: Release Changelog'
 backlink_href: /docs/enterprise
-backlink_title: 'pganalyze Enterprise Edition'
+backlink_title: 'pganalyze Enterprise Server'
 ---
 
 * [2022.05.1 Release](/docs/enterprise/releases/2022-05-1)

--- a/enterprise/setup/index.mdx
+++ b/enterprise/setup/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'Enterprise Edition: Initial Setup'
+title: 'Enterprise Server: Initial Setup'
 backlink_href: /docs/enterprise
-backlink_title: 'pganalyze Enterprise Edition'
+backlink_title: 'pganalyze Enterprise Server'
 ---
 
 import ToC from '../../components/Toc'
 
-These are the installation instructions for [pganalyze Enterprise Edition](/enterprise-postgres-monitoring), which runs fully-contained within your own environment.
+These are the installation instructions for [pganalyze Enterprise Server](/enterprise-postgres-monitoring), which runs fully-contained within your own environment.
 
 The pganalyze Docker image is mostly self-contained, and runs various services inside the Docker container.
 
@@ -19,7 +19,7 @@ The pganalyze Docker image is mostly self-contained, and runs various services i
 * Provision a virtual machine
   * Assign at least 4GB - 8GB of RAM, 1-2 dedicated CPU cores
 * Install Docker on your virtual machine
-  * pganalyze Enterprise Edition is delivered through a Docker image
+  * pganalyze Enterprise Server is delivered through a Docker image
 * Setup a PostgreSQL database that can be used for storing statistics data
   * PostgreSQL 10 or newer
   * 50 GB of dedicated disk space or more
@@ -39,7 +39,7 @@ docker login -e="." -u="pganalyze+enterprise_customer" -p="YOUR_PASSWORD" quay.i
 
 Note that this will add the login information to your current user's `.dockercfg` file - you will need this on every host where you'd like to access the image.
 
-You should now be able to pull the pganalyze Enterprise Edition Docker image:
+You should now be able to pull the pganalyze Enterprise Server Docker image:
 
 ```
 docker pull quay.io/pganalyze/enterprise:[version]

--- a/enterprise/setup/kubernetes_amazon_eks.mdx
+++ b/enterprise/setup/kubernetes_amazon_eks.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'Enterprise Edition: Initial Setup (Kubernetes on Amazon EKS)'
+title: 'Enterprise Server: Initial Setup (Kubernetes on Amazon EKS)'
 backlink_href: /docs/enterprise
-backlink_title: 'pganalyze Enterprise Edition'
+backlink_title: 'pganalyze Enterprise Server'
 ---
 
 import ToC from '../../components/Toc'
 
-These are the installation instructions for [pganalyze Enterprise Edition](/enterprise-postgres-monitoring), targeted for a Kubernetes cluster managed by Amazon EKS in your own AWS account.
+These are the installation instructions for [pganalyze Enterprise Server](/enterprise-postgres-monitoring), targeted for a Kubernetes cluster managed by Amazon EKS in your own AWS account.
 
 <ToC items={props.toc} />
 

--- a/enterprise/setup/object-storage-local.mdx
+++ b/enterprise/setup/object-storage-local.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Enterprise Edition: Log Insights Setup (Local Storage)'
+title: 'Enterprise Server: Object Storage Setup (Local Storage)'
 backlink_href: /docs/enterprise/log-insights
-backlink_title: 'pganalyze Enterprise Edition: Log Insights Setup'
+backlink_title: 'pganalyze Enterprise Server: Object Storage Setup'
 ---
 
 ### 1. Installation of the Minio storage server

--- a/enterprise/setup/object-storage-s3.mdx
+++ b/enterprise/setup/object-storage-s3.mdx
@@ -1,16 +1,16 @@
 ---
-title: 'Enterprise Edition: Log Insights Setup (Amazon S3)'
+title: 'Enterprise Server: Object Storage Setup (Amazon S3)'
 backlink_href: /docs/enterprise/log-insights
-backlink_title: 'pganalyze Enterprise Edition: Log Insights Setup'
+backlink_title: 'pganalyze Enterprise Server: Object Storage Setup'
 ---
 
 ## 1. Pre-requisites
 
-Log Insights for pganalyze Enterprise Edition currently requires the following when storing logs in Amazon S3 and encrypting them using KMS:
+pganalyze Enterprise Server currently requires the following when storing statistics snapshots and logs in Amazon S3:
 
 - An Amazon S3 bucket to be used for temporary statistics data
 - An Amazon S3 bucket to be used for log data (this is where encrypted log data will be stored)
-- An Amazon KMS key to be used for encryption (you can find KMS under "Encryption Keys" in the IAM console)
+- An Amazon KMS key to be used for log text encryption (you can find KMS under "Encryption Keys" in the IAM console)
 - An Amazon IAM user that can access the S3 bucket and KMS key (we need the keys in the next steps)
 
 The setup for these should be straightforward - we recommend choosing a region thats close to your database servers, but latency shouldn't be too much of an issue in general.

--- a/enterprise/setup/object-storage.mdx
+++ b/enterprise/setup/object-storage.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Enterprise Server: Object Storage Setup'
+backlink_href: /docs/enterprise
+backlink_title: 'pganalyze Enterprise Server'
+---
+
+## Setting up an object storage backend
+
+Using pganalyze Enterprise Server with Log Insights requires some additional
+configuration for object storage. This is also required
+when running a [separate collector installation](/docs/enterprise/separate-collector-install).
+
+The object storage (e.g. Amazon S3) is used for two purposes:
+
+* Statistics snapshots - as a communication channel for sending statistics data
+* Log texts - to store log texts for the retention time (7 days)
+
+Please make a choice of which object storage to use and follow one of these two guides:
+
+1. [Local storage using the Minio storage server](/docs/enterprise/setup/object-storage-local)
+
+2. [Cloud storage using Amazon S3](/docs/enterprise/setup/object-storage-s3)

--- a/enterprise/setup/separate-collector-install.mdx
+++ b/enterprise/setup/separate-collector-install.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Enterprise Server: Separate collector installation'
+backlink_href: /docs/enterprise
+backlink_title: 'pganalyze Enterprise Server'
+---
+
+## Set up separate collector installation
+
+You may choose to run the collector outside of the pganalyze Enterprise Server container, for example to make use of all available [collector settings](/docs/collector/settings), or to better support a given network architecture.
+
+Note that this is different from the Enterprise Server setup we recommend for getting started, which runs the collector inside the central pganalyze Docker container.
+
+For using a separate collector, you do not need to add the server into pganalyze itself, as it will auto-register based on an API key, and send all statistics from the database server (instead of pulling them).
+
+### Pre-requisites
+
+* Enable the [object storage](/docs/enterprise/setup/object-storage) on your pganalyze Enterprise Server container.
+
+* Retrieve the collector API key from the "API Keys" organization tab in pganalyze (it should already be listed there). If you don't see it in the navigation make sure to click on your organization in the organization dropdown first.
+
+* Get the hostname of your pganalyze Enterprise Server container, which needs to be reachable from your database server.
+
+### Installing the collector
+
+Now install and enable the pganalyze collector on a database server (for self-managed servers) or on a nearby VM/container (for managed database providers), by following the cloud-based [instructions for collector setup](/docs/install).
+
+Note that you should be able to follow these instructions as written, with one difference. The `[pganalyze]` section of the config file needs to look like this, with the added `api_base_url` setting, which points to your central pganalyze Enterprise Server container (or a load balancer in front of it):
+
+```
+[pganalyze]
+api_key: your_pga_organization_api_key
+api_base_url: http://your-docker-container.internal
+```
+
+You can follow the regular instructions to issue a test command, and after a successful test you should see data show in the dashboard within 10-20 minutes.

--- a/enterprise/troubleshooting.mdx
+++ b/enterprise/troubleshooting.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'Enterprise Edition: Troubleshooting'
+title: 'Enterprise Server: Troubleshooting'
 backlink_href: /docs/enterprise
-backlink_title: 'pganalyze Enterprise Edition'
+backlink_title: 'pganalyze Enterprise Server'
 ---
 
 ## Error: License Invalid or Expired
 
 If you see the notice `Error: License Invalid or Expired` when logging into pganalyze,
-it means that pganalyze Enterprise Edition wasn't able to verify the `LICENSE_KEY` that
+it means that pganalyze Enterprise Server wasn't able to verify the `LICENSE_KEY` that
 is passed.
 
 **Step 1:** Verify that you are passing `LICENSE_KEY` to the Docker container. Your license

--- a/enterprise/upgrade.mdx
+++ b/enterprise/upgrade.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'Enterprise Edition: Upgrading to new releases'
+title: 'Enterprise Server: Upgrading to new releases'
 backlink_href: /docs/enterprise
-backlink_title: 'pganalyze Enterprise Edition'
+backlink_title: 'pganalyze Enterprise Server'
 ---
 
 ## Upgrade process
 
-The general upgrade process for pganalyze Enterprise Edition is as follows:
+The general upgrade process for pganalyze Enterprise Server is as follows:
 
 **1. Backup the statistics database (pg_dump or RDS snapshot)**
 
@@ -69,7 +69,7 @@ Starting in pganalyze Enterprise [2018.08.0](/docs/enterprise/releases/2018-08-0
 container requires the `LICENSE_KEY` environment variable to be configured.
 
 Before starting the new container, set the `LICENSE_KEY` environment variable to
-the download password that you have been given when first setting up pganalyze Enterprise Edition.
+the download password that you have been given when first setting up pganalyze Enterprise Server.
 
 Note that this requires the container to be able to make an HTTPS connection (port 443) to
 `enterprise-license-check.pganalyze.com` - if this is not possible in your setup

--- a/index.mdx
+++ b/index.mdx
@@ -94,13 +94,19 @@ title: 'Documentation'
       * [Unique](/docs/explain/other-nodes/unique)
       * [Window Aggregate](/docs/explain/other-nodes/window-aggregate)
 
-* **[Enterprise Edition](/docs/enterprise)**
+* **[pganalyze Enterprise Server](/docs/enterprise)**
   - [Initial Setup on a VM](/docs/enterprise/setup)
   - [Initial Setup on Kubernetes (Amazon EKS)](/docs/enterprise/setup/kubernetes_amazon_eks)
-  - [Release Changelog](/docs/enterprise/releases)
-  - [Log Insights Setup](/docs/enterprise/log-insights)
+  - [Object Storage Setup](/docs/enterprise/setup/object-storage)
+    - [Local Storage using Minio](/docs/enterprise/setup/object-storage-local)
+    - [Cloud Storage using Amazon S3](/docs/enterprise/setup/object-storage-s3)
+  - [Separate collector installation](/docs/enterprise/setup/separate-collector-install)
   - [Google Auth Setup](/docs/enterprise/google-auth)
+  - [PagerDuty and Slack Integration Setup](/docs/enterprise/integrations)
+  - [Release Changelog](/docs/enterprise/releases)
   - [Upgrading to new releases](/docs/enterprise/upgrade)
+  - [Reference Architecture](/docs/enterprise/architecture)
+  - [Troubleshooting](/docs/enterprise/troubleshooting)
 
 * **[pganalyze GraphQL API](/docs/api)**
   - [Creating an API key](/docs/api/create-api-key)
@@ -108,7 +114,7 @@ title: 'Documentation'
       * [getIssues - Get check-up issues and alerts](/docs/api/queries/getIssues)
       * [getQueryStats - Export query statistics](/docs/api/queries/getQueryStats)
   - [Mutations](/docs/api/mutations)
-      * [addServer - Add a server to pganalyze Enterprise Edition](/docs/api/mutations/addServer)
+      * [addServer - Add a server to pganalyze Enterprise Server](/docs/api/mutations/addServer)
 
 <>{/* **[Guides](/docs/guides)**
   - [Tuning checkpoint intervals to reduce I/O spikes](/docs/guides/tuning-checkpoint-intervals)

--- a/open_source_components.mdx
+++ b/open_source_components.mdx
@@ -4,19 +4,6 @@ backlink_href: /docs
 backlink_title: 'Documentation'
 ---
 
-## pgdatagraph
-
-![](https://raw.githubusercontent.com/pganalyze/pgdatagraph/master/screenshot.png)
-
-[pgdatagraph](https://github.com/pganalyze/pgdatagraph) is an interactive widget
-for graphing time-series data - based on [D3](http://d3js.org/) and
-[Rickshaw](http://code.shutterstock.com/rickshaw/).
-
-It's used throughout pganalyze for all the graphs you see. Its goal is to enable
-exploration and interaction with the data.
-
----
-
 ## pganalyze collector
 
 [pganalyze collector](https://github.com/pganalyze/collector)


### PR DESCRIPTION
This clarifies that object storage is useful beyond just Log Insights,
adds a dedicated page for installing the collector separately, and
adds a new page that describes a scaled out reference architecture.

Additionally we use "Enterprise Server" going forward, instead of
"Enterprise Edition".