### PR TITLE
Introduce dedicated page for Enterprise Server container settings

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -208,6 +208,10 @@
       "title": "2022.08.1 Release",
       "path": "/docs/enterprise/releases/2022-08-1"
     },
+    "enterprise/settings": {
+      "title": "Enterprise Server: Container settings",
+      "path": "/docs/enterprise/settings"
+    },
     "enterprise/setup": {
       "title": "Enterprise Server: Initial Setup",
       "path": "/docs/enterprise/setup"

--- a/enterprise/index.mdx
+++ b/enterprise/index.mdx
@@ -13,18 +13,19 @@ If you'd like to start a trial of pganalyze Enterprise Server in your environmen
 
 ## Setup instructions
 
-- [Initial Setup on a VM](/docs/enterprise/setup)
-- [Initial Setup on Kubernetes (Amazon EKS)](/docs/enterprise/setup/kubernetes_amazon_eks)
-- [Object Storage Setup](/docs/enterprise/setup/object-storage)
+- [Initial setup on a VM](/docs/enterprise/setup)
+- [Initial setup on Kubernetes (Amazon EKS)](/docs/enterprise/setup/kubernetes_amazon_eks)
+- [Object storage setup](/docs/enterprise/setup/object-storage)
   - [Local Storage using Minio](/docs/enterprise/setup/object-storage-local)
   - [Cloud Storage using Amazon S3](/docs/enterprise/setup/object-storage-s3)
 - [Separate collector installation](/docs/enterprise/setup/separate-collector-install)
-- [Google Auth Setup](/docs/enterprise/google-auth)
-- [PagerDuty and Slack Integration Setup](/docs/enterprise/integrations)
+- [Google Auth setup](/docs/enterprise/google-auth)
+- [PagerDuty and Slack integration setup](/docs/enterprise/integrations)
+- [Container settings](/docs/enterprise/settings)
 
 ## Other information
 
-- [Release Changelog](/docs/enterprise/releases)
+- [Release changelog](/docs/enterprise/releases)
 - [Upgrading to new releases](/docs/enterprise/upgrade)
-- [Reference Architecture](/docs/enterprise/architecture)
+- [Reference architecture](/docs/enterprise/architecture)
 - [Troubleshooting](/docs/enterprise/troubleshooting)

--- a/enterprise/log-insights.mdx
+++ b/enterprise/log-insights.mdx
@@ -4,44 +4,21 @@ backlink_href: /docs/enterprise
 backlink_title: 'pganalyze Enterprise Edition'
 ---
 
-## Setting up a storage backend
+<!-- Note this page is no longer referenced directly in the public docs, but still linked from in-app-->
 
-Using pganalyze Enterprise Edition with Log Insights requires some additional
-configuration, which is described in this document.
+## Log Insights setup
 
-First of all, you need to decide where to store the log files. Please make a choice
-and follow one of these two guides:
+Using pganalyze Enterprise Edition with Log Insights and Automated EXPLAIN requires some additional
+configuration.
 
-1. [Local storage using the Minio storage server](/docs/enterprise/log-insights-local)
+First of all, you need to [set up the object storage integration](/docs/enterprise/setup/object-storage).
 
-2. [Cloud storage using Amazon S3](/docs/enterprise/log-insights-s3)
+Once you have successfully completed this:
 
-Once you have successfully completed this, you can change the collector setup
-to run on the database servers themselves, in order to have log access:
+* For Amazon RDS and Aurora you can turn on the Log Insights flag on your servers in the settings page, or run the collector separately
+* For self-managed servers, you can either [add the pg_read_file helper](https://github.com/pganalyze/collector#setting-up-log-pg_read_file-helper) and then turn on the Log Insights flag on the server settings page, or run the collector separately
+* For all other providers you need to run the collector separately
 
-## Setup collector on self-managed database servers
+For running the collector separately, see [separate collector installation](/docs/enterprise/setup/separate-collector-install)
 
-In order to collect log information from your database server you will need to install the collector on
-the server itself, and configure it.
-
-Note that this is different from the standard Enterprise setup, which runs the collector inside the central pganalyze Docker container.
-
-For this approach, you do not need to add the server into pganalyze itself, as it will auto-register based on an API key, and send all statistics from the database server (instead of pulling them).
-
-Before we get started, retrieve the collector API key from the "API Keys" organization tab in pganalyze (it should already be listed there). If you don't see it in the navigation make sure to click on your organization in the organization dropdown first.
-
-You will also need the hostname of your pganalyze Docker container, which needs to be reachable from your database server.
-
-Now install and enable the pganalyze collector on a server, following the [instructions for pganalyze.com](/docs/install/self_managed/00_choose_setup_method).
-
-Note that you should be able to follow these instructions as written, with one difference. The [pganalyze] section of the config file needs to look like this:
-
-```
-[pganalyze]
-api_key: your_pga_organization_api_key
-api_base_url: http://your-docker-container.internal
-```
-
-Once this works successfully, you can enable [Log Insights for self-managed servers](/docs/log-insights/setup/self-managed).
-
-You should then see data flow into the dashboard correctly.
+You should then see data flow into the dashboard correctly. To troubleshoopt we recommend running a collector test. When using the collector inside the pganalyze Enterprise Server image, you can do so from the Server Settings page ("Collector Configuration Test").

--- a/enterprise/settings.mdx
+++ b/enterprise/settings.mdx
@@ -1,0 +1,122 @@
+---
+title: 'Enterprise Server: Container settings'
+backlink_href: /docs/enterprise
+backlink_title: 'pganalyze Enterprise Server'
+---
+
+import ToC from '../components/Toc'
+
+The settings on this page can be passed in as environment variables into the pganalyze Enterprise Server container. Any change of these settings requires a container restart to read the new configuration.
+
+<ToC items={props.toc} />
+
+## Basic configuration
+
+* `DATABASE_URL`: PostgreSQL server used for storing statistics information (required)
+* `LICENSE_KEY`: License key provided to you by the pganalyze team (required)
+* `DOMAIN_NAME`: Domain name where you are hosting the pganalyze app (optional, but recommended, and required for SSO)
+* `MAILER_URL`: SMTP server used to send system emails, e.g. user invites (optional, recommended)
+* `MAILER_FROM`: "From" address used to send system emails (optional, recommended if setting MAILER_URL)
+* `REDIS_URL`: Redis server used for [scale out architecture](/enterprise/architecture) (optional, only needed when running Redis separately)
+* `DEFAULT_ORG_ROLE`: How new users are added to the organization when they sign up (optional, default: `none`)
+  - `none` - new users are not organization members and have to be invited by an existing user
+  - `admin` - assigns the role named "Admin (All Servers)"
+  - `modify_all` - assigns the role named "View & Modify (All Servers)"
+  - `view_all` - assigns the role named "View (All Servers)"
+
+An example configuration looks like this:
+
+```
+DATABASE_URL=postgres://myusername:mypassword@example.com:5432/mydatabase
+LICENSE_KEY=KEYKEYKEY
+DOMAIN_NAME=pganalyze.example.com
+MAILER_URL=smtp://myusername:mypassword@example.com:25
+MAILER_FROM=pganalyze@example.com
+```
+
+## Object storage
+
+For using Log Insights and Automated EXPLAIN, additional settings must be configured for [object storage](/docs/enterprise/setup/object-storage).
+
+## AWS-specific settings
+
+When using the [object storage on AWS](/docs/enterprise/setup/object-storage-s3), the required IAM credentials can either be set using an instance role (recommended), or by explicitly setting these environment variables:
+
+* `AWS_ACCESS_KEY_ID`: AWS Access Key ID (optional)
+* `AWS_SECRET_ACCESS_KEY`: AWS Secret Access Key (optional)
+
+You can also configure the following object storage settings:
+
+* `AWS_S3_SNAPSHOTS_BUCKET`: Name of the snapshots S3 bucket (required for object storage)
+* `AWS_S3_LOGS_BUCKET`: Name of the logs S3 bucket (required for object storage)
+* `AWS_KMS_LOGS_CMK`: Identifier for the KMS key used for client-side log text encryption (required for object storage)
+* `AWS_S3_SNAPSHOTS_PREFIX`: Prefix for all objects stored in snapshots bucket (optional, empty by default)
+* `AWS_S3_LOGS_PREFIX`: Prefix for all objects stored in logs bucket (optional, empty by default)
+
+Note that when using the collector inside the Enterprise Server container to monitor Amazon RDS or Aurora, the actual fetching of log data from RDS will also use these same credentials. Ensure to also set the [collector IAM policy](/docs/install/amazon_rds/03_setup_iam_policy) in that case.
+
+In addition, you can also set these other general settings:
+
+* `AWS_REGION`: Default AWS region (optional)
+* `AWS_ENDPOINT_S3_URL`: VPC endpoint to use for Amazon S3 API access (optional)
+* `AWS_ENDPOINT_KMS_URL`: VPC endpoint to use for Amazon KMS API access (optional)
+* `AWS_ENDPOINT_STS_URL`: VPC endpoint to use for Amazon STS API access (optional)
+
+When using Amazon EKS with [IAM roles associated to a service account](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html), the following additional settings can be used:
+
+* `AWS_ROLE_ARN`: Role to assume for AWS API access (automatically set by EKS)
+* `AWS_WEB_IDENTITY_TOKEN_FILE`: Location of Web Identity token file (automatically set by EKS)
+* `AWS_ROLE_SESSION_NAME`: Session name to use when assuming roles (optional, defaults to "pganalyze")
+
+## Local object storage with Minio
+
+See [Object Storage Setup (Local Storage)](/docs/enterprise/setup/object-storage-local).
+
+Additionally the following optional settings are available:
+
+* `MINIO_SNAPSHOTS_BUCKET`: Name of the snapshots bucket in Minio (optional, defaults to `pganalyze-snapshots`)
+* `MINIO_LOGS_BUCKET`: Name of the logs bucket in Minio (optional, defaults to `pganalyze-logs`)
+
+## Google Auth integration
+
+Configured using `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. See [separate instructions](/docs/enterprise/google-auth).
+
+## PagerDuty integration
+
+Configured using `PAGERDUTY_APP_ID`. See [separate instructions](/docs/enterprise/integrations).
+
+## Slack integration
+
+Configured using `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET`. See [separate instructions](/docs/enterprise/integrations).
+
+## LDAP configuration
+
+The collector can optionally support using an LDAP connection to verify user credentials, instead of using a username/password stored in the pganalyze database. When LDAP is enabled regular user authentication is turned off.
+
+LDAP is commonly utilized when using Microsoft Active Directory on-premise. If possible we recommend using the [SAML integration](/docs/accounts/sso) instead, including when using Azure Active Directory.
+
+When using LDAP, it is recommended to also set `DEFAULT_ORG_ROLE` to a non-empty value (see above)
+to ensure that new LDAP users are added to the existing organization.
+
+* `LDAP_HOST`: Internal hostname or IP of your LDAP server
+* `LDAP_PORT`: Port of your LDAP server. Use port 636 for LDAPS
+* `LDAP_BASE_DN`: Base DN that all lookups should be done with. You can use this to restrict access to a subset of your LDAP accounts. Note that both the admin CN and regular users need to be members of this DN.
+* `LDAP_LOOKUP_CN`: Common Name of an account that will be used to run authentication lookups on your LDAP directory
+* `LDAP_LOOKUP_PASSWORD`: Password for the account that will be used to run authentication lookups
+* `LDAP_FIELD_UID`: UID field on your LDAP entries. This is usually `sAMAccountName` on Active Directory servers
+* `LDAP_ENCRYPTION`: Encryption mode to use for LDAP connections. Only add this when you want to use LDAPS (Port 636) or STARTTLS (Port 389) for a secure connection to your server. Specify `ssl` for LDAPS, and `tls` for STARTTLS (optional)
+
+Example LDAP configuration, with the required `DEFAULT_ORG_ROLE` setting, but without other unrelated settings:
+
+```
+LDAP_HOST=example.com
+LDAP_PORT=389
+LDAP_BASE_DN=OU=Users,OU=ldaptest,DC=ldaptest,DC=pganalyze,DC=com
+LDAP_LOOKUP_CN=Admin
+LDAP_LOOKUP_PASSWORD=ReallyLongSecurePassword
+LDAP_FIELD_UID=sAMAccountName
+LDAP_ENCRYPTION=ssl
+DEFAULT_ORG_ROLE=view_all
+```
+
+Note you can run an [Enterprise self-check](/docs/enterprise/troubleshooting) to verify the connection and lookup LDAP information, but some configuration errors are only visible once logging in.

--- a/enterprise/setup/index.mdx
+++ b/enterprise/setup/index.mdx
@@ -23,9 +23,9 @@ The pganalyze Docker image is mostly self-contained, and runs various services i
 * Setup a PostgreSQL database that can be used for storing statistics data
   * PostgreSQL 10 or newer
   * 50 GB of dedicated disk space or more
-* Optional: If you use the RDS integration, setup an appropriate IAM role that can be used
+* Optional: If you use the RDS integration, setup an appropriate IAM role that can be used to download logs and system metrics
   * You can also assign the required policy to an existing EC2 instance and its instance role
-  * Appendix A lists out the exact IAM policy
+  * You will need both the [collector IAM policy](/docs/install/amazon_rds/03_setup_iam_policy) as well as the [object storage IAM policy](/docs/enterprise/setup/object-storage-s3)
 
 ### Step 1: Download the Docker Image
 
@@ -60,7 +60,9 @@ MAILER_URL=smtp://myusername:mypassword@example.com:25
 LICENSE_KEY=KEYKEYKEY
 ```
 
-You can find the full explanation of all variables in Appendix C.
+If you'd like to use the Log Insights or Automated EXPLAIN features, or want to run the collector separately from the Enterprise Server container, you also need to pass the [object storage configuration](/docs/enterprise/setup/object-storage) here.
+
+You can find the full explanation of all variables in the [settings documentation](/enterprise/settings).
 
 
 ### Step 3: Initialize Database & Verify Installation
@@ -189,151 +191,4 @@ For regular setups, you can invite additional team members on a per-database bas
 
 With LDAP authentication you can simply direct your colleagues to the root of your pganalyze URL, an account will be created when they first login.
 
-Note that only administrators can add new databases (see Appendix B).
-
-
-## Appendix
-
-### Appendix A - Amazon Web Services IAM Role
-
-Your IAM role will need two policies assigned - at first, the predefined `AmazonRDSReadOnlyAccess` policy that gives access to most Amazon RDS information and statistics.
-
-In addition, you'll also need to add an inline policy with the following content, if you want to use the log monitoring feature:
-
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "rds:Describe*",
-                "rds:ListTagsForResource",
-                "ec2:DescribeAccountAttributes",
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeVpcs"
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-        },
-        {
-            "Action": [
-                "cloudwatch:GetMetricStatistics",
-                "logs:DescribeLogStreams",
-                "logs:GetLogEvents"
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-        },
-        {
-            "Action": [ "rds:DownloadDBLogFilePortion" ],
-            "Effect": "Allow",
-            "Resource": "*"
-        }
-    ]
-}
-```
-
-This is required so that pganalyze can access and download the log files for each instance.
-
-
-### Appendix B - User Roles
-
-Administrator roles:
-* Can create new databases
-* Can access the /admin pages
-* Can modify database settings
-* Can delete databases
-
-Normal user roles:
-* Can view statistics and query information
-* Can view automated Check-Up information, and mark check-ups as acknowledged
-* Receive weekly email reports (if enabled)
-
-Users without valid accounts cannot access any information.
-
-
-### Appendix C - Environment Variables
-
-The following environment variables can be passed into the Docker image. Note that the examples are listed with multiple lines here for formatting reasons, but you need to pass them as one line.
-
-* `DATABASE_URL`: PostgreSQL server used for storing statistics information (required)
-* `LICENSE_KEY`: License key provided to you by the pganalyze team (required)
-* `DOMAIN_NAME`: Domain name where you are hosting the pganalyze app (optional, but recommended, and required for SSO)
-* `MAILER_URL`: SMTP server used to send system emails, e.g. user invites (optional, recommended)
-* `MAILER_FROM`: "From" address used to send system emails (optional, recommended if setting MAILER_URL)
-* `AWS_ACCESS_KEY_ID:` AWS Access Key ID (optional)
-* `AWS_SECRET_ACCESS_KEY`: AWS Secret Access Key (optional)
-* `AWS_REGION`: Default AWS region (optional)
-* `DEFAULT_ORG_ROLE`: How new users are added to the organization when they sign up (optional, default: `none`)
-  - `none` - new users are not organization members and have to be invited by an existing user
-  - `admin` - assigns the role named "Admin (All Servers)"
-  - `modify_all` - assigns the role named "View & Modify (All Servers)"
-  - `view_all` - assigns the role named "View (All Servers)"
-
-An example configuration looks like this:
-
-```
-DATABASE_URL=postgres://myusername:mypassword@example.com:5432/mydatabase
-LICENSE_KEY=KEYKEYKEY
-DOMAIN_NAME=pganalyze.example.com
-MAILER_URL=smtp://myusername:mypassword@example.com:25
-MAILER_FROM=pganalyze@example.com
-AWS_ACCESS_KEY_ID=AKIAXXXXXXXXXXXX
-AWS_SECRET_ACCESS_KEY=ReallyLongStringYouWillGetFromYourAwsConsole
-AWS_REGION=us-east-1
-```
-
-### Appendix D - LDAP configuration
-
-When using LDAP, it is recommended to also set DEFAULT_ORG_ROLE to a non-empty value (see above)
-to ensure that new LDAP users are added to the existing organization.
-
-
-* `LDAP_HOST`: Internal hostname or IP of your LDAP server
-* `LDAP_PORT`: Port of your LDAP server. Use port 636 for LDAPS
-* `LDAP_BASE_DN`: Base DN that all lookups should be done with. You can use this to restrict access to a subset of your LDAP accounts
-* `LDAP_ADMIN_GROUP_CN`: Common Name of the group used to identify pganalyze admins. Note that members don’t need to be LDAP admins
-* `LDAP_LOOKUP_CN`: Common Name of an account that will be used to run authentication lookups on your LDAP directory
-* `LDAP_LOOKUP_PASSWORD`: Password for the account that will be used to run authentication lookups
-* `LDAP_FIELD_UID`: UID field on your LDAP entries. This is usually `sAMAccountName` on Active Directory servers
-* `LDAP_ENCRYPTION`: Encryption mode to use for LDAP connections. Only add this when you want to use LDAPS (Port 636) or STARTTLS (Port 389) for a secure connection to your server. Specify `ssl` for LDAPS, and `tls` for STARTTLS (optional)
-
-Example LDAP configuration, in addition to regular environment variables:
-
-```
-LDAP_HOST=example.com
-LDAP_PORT=389
-LDAP_BASE_DN=OU=Users,OU=ldaptest,DC=ldaptest,DC=pganalyze,DC=com
-LDAP_ADMIN_GROUP_CN=opsteam
-LDAP_LOOKUP_CN=Admin
-LDAP_LOOKUP_PASSWORD=ReallyLongSecurePassword
-LDAP_FIELD_UID=sAMAccountName
-LDAP_ENCRYPTION=ssl
-```
-
-If LDAP authentication does not work, or you see an error message instead of this form, please check the container's logs using `docker logs` and verify your `LDAP_ADMIN_GROUP_CN` setting.
-
-### Appendix E - Command Line Debugging Tools
-
-There are two essential debugging tools:
-
-#### Enterprise Self Check
-
-```
-docker run --env-file ... rake enterprise:self_check
-```
-
-Verifies the environment variables you have passed in for errors.
-
-#### Docker Container Logs
-
-```
-docker logs -f pganalyze
-```
-
-Shows the full log messages from the pganalyze container - if you encounter an error screen in the software this will show the details. This information will be required when submitting issues to our support team.
-
-### Appendix F - Updating to a new Version
-
-See [upgrade instructions](/docs/enterprise/upgrade).
+Note that only users with the "Manage" permission can add new databases (see [Permissions and Roles](/docs/accounts/permissions)).

--- a/enterprise/troubleshooting.mdx
+++ b/enterprise/troubleshooting.mdx
@@ -4,7 +4,33 @@ backlink_href: /docs/enterprise
 backlink_title: 'pganalyze Enterprise Server'
 ---
 
-## Error: License Invalid or Expired
+## Tools
+
+## Self-check
+
+You can run the following command to check the configuration for basic errors:
+
+```
+docker run --env-file ... rake enterprise:self_check
+```
+
+This verifies the Postgres, Redis, SMTP and LDAP configuration (if applicable), as well as confirms that the license is active.
+
+### Docker Container Logs
+
+When running Docker on a virtual machine to run pganalyze, you can run the following command:
+
+```
+docker logs -f pganalyze
+```
+
+This will show the full log messages from the pganalyze app, as well as errors from the collector inside the Enterprise Server container.
+
+If you encounter an error screen in the software this will show the details. This information will be required when submitting issues to our support team.
+
+## Common errors
+
+### Error: License Invalid or Expired
 
 If you see the notice `Error: License Invalid or Expired` when logging into pganalyze,
 it means that pganalyze Enterprise Server wasn't able to verify the `LICENSE_KEY` that

--- a/index.mdx
+++ b/index.mdx
@@ -95,17 +95,17 @@ title: 'Documentation'
       * [Window Aggregate](/docs/explain/other-nodes/window-aggregate)
 
 * **[pganalyze Enterprise Server](/docs/enterprise)**
-  - [Initial Setup on a VM](/docs/enterprise/setup)
-  - [Initial Setup on Kubernetes (Amazon EKS)](/docs/enterprise/setup/kubernetes_amazon_eks)
-  - [Object Storage Setup](/docs/enterprise/setup/object-storage)
-    - [Local Storage using Minio](/docs/enterprise/setup/object-storage-local)
-    - [Cloud Storage using Amazon S3](/docs/enterprise/setup/object-storage-s3)
-  - [Separate collector installation](/docs/enterprise/setup/separate-collector-install)
-  - [Google Auth Setup](/docs/enterprise/google-auth)
-  - [PagerDuty and Slack Integration Setup](/docs/enterprise/integrations)
-  - [Release Changelog](/docs/enterprise/releases)
+  - Setup instructions
+    - [Initial setup on a VM](/docs/enterprise/setup)
+    - [Initial setup on Kubernetes (Amazon EKS)](/docs/enterprise/setup/kubernetes_amazon_eks)
+    - [Object storage setup](/docs/enterprise/setup/object-storage)
+    - [Separate collector installation](/docs/enterprise/setup/separate-collector-install)
+    - [Google Auth setup](/docs/enterprise/google-auth)
+    - [PagerDuty and Slack integration setup](/docs/enterprise/integrations)
+    - [Container settings](/docs/enterprise/settings)
+  - [Release changelog](/docs/enterprise/releases)
   - [Upgrading to new releases](/docs/enterprise/upgrade)
-  - [Reference Architecture](/docs/enterprise/architecture)
+  - [Reference architecture](/docs/enterprise/architecture)
   - [Troubleshooting](/docs/enterprise/troubleshooting)
 
 * **[pganalyze GraphQL API](/docs/api)**


### PR DESCRIPTION
In the past this information has been scattered across multiple pages,
making it hard to get an overview. Instead create a dedicated page, like
we have for collector settings.

In passing remove all appendixes from the VM-based setup, make instructions
a bit less AWS specific in places (be explicit about when the AWS settings
are needed), and move troubleshooting steps to the troubleshooting page.

This also cleans up the Log Insights setup page, which was mostly moved
to the object storage setup instructions and separate collector install
steps, but still needs to exist to be linked from in-app. Modify it to
avoid duplication with the other new pages added in prior commits.

Last, this removes the LDAP_ADMIN_GROUP_CN setting documentation, since
that setting has not been supported in Enterprise Server for a while.