### PR TITLE
AWS IAM policy: Add "rds:DescribeDBClusters" requirement

### DIFF
--- a/install/amazon_rds/03_setup_iam_policy.mdx
+++ b/install/amazon_rds/03_setup_iam_policy.mdx
@@ -21,7 +21,6 @@ To start, go to **[Create IAM policy](https://console.aws.amazon.com/iam/home#/p
     "Statement": [
         {
             "Action": [
-                "rds:DescribeDBInstances",
                 "cloudwatch:GetMetricStatistics"
             ],
             "Effect": "Allow",
@@ -43,6 +42,8 @@ To start, go to **[Create IAM policy](https://console.aws.amazon.com/iam/home#/p
         },
         {
             "Action": [
+                "rds:DescribeDBClusters",
+                "rds:DescribeDBInstances",
                 "rds:DownloadDBLogFilePortion",
                 "rds:DescribeDBLogFiles"
             ],


### PR DESCRIPTION
This is needed for the new automatic discovery of writer and two-node
cluster reader instances in the collector.

In passing move "rds:DescribeDBInstances" together with the other
RDS-specific resources, instead of listing it as requiring "*".