### PR TITLE
RDS docs: Replace note on track_activity_query_size with track_io_timing

### DIFF
--- a/install/amazon_rds/_01_public.mdx
+++ b/install/amazon_rds/_01_public.mdx
@@ -1,10 +1,7 @@
 import imgRdsParamGroup from '../../images/rds_parameter_group.png'
-import imgRdsParamGroup2 from '../../images/rds_parameter_group2.gif'
 import imgRdsEnableParamGroup from '../../images/rds_enable_parameter_group.png'
 
 export const ImgRdsParamGroup = () => <img src={imgRdsParamGroup} />
-
-export const ImgRdsParamGroup2 = () => <img src={imgRdsParamGroup2} />
 
 export const ImgRdsEnableParamGroup = () => <img src={imgRdsEnableParamGroup} />
 
@@ -27,13 +24,11 @@ In your [AWS Console](https://console.aws.amazon.com/rds/), modify your existing
 
 Then set the following configuration parameters:
 
-<ImgRdsParamGroup2 />
-
  Name | New Value | &nbsp;
  ---- | ------ | -------
  [pg\_stat\_statements.track](https://www.postgresql.org/docs/current/pgstatstatements.html#id-1.11.7.39.9) | ALL | Optional, enables tracking of queries inside stored procedures
 [shared\_preload\_libraries](https://www.postgresql.org/docs/current/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-PRELOAD) | pg\_stat\_statements
-[track\_activity\_query\_size](https://www.postgresql.org/docs/current/runtime-config-statistics.html#RUNTIME-CONFIG-STATISTICS-COLLECTOR) | 2048
+ [track\_io\_timing](https://www.postgresql.org/docs/current/runtime-config-statistics.html#RUNTIME-CONFIG-STATISTICS-COLLECTOR) | on | Optional, enables tracking of per-query I/O statistics
 
 ---
 

--- a/install/amazon_rds/_01_public.mdx
+++ b/install/amazon_rds/_01_public.mdx
@@ -28,7 +28,7 @@ Then set the following configuration parameters:
  ---- | ------ | -------
  [pg\_stat\_statements.track](https://www.postgresql.org/docs/current/pgstatstatements.html#id-1.11.7.39.9) | ALL | Optional, enables tracking of queries inside stored procedures
 [shared\_preload\_libraries](https://www.postgresql.org/docs/current/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-PRELOAD) | pg\_stat\_statements
- [track\_io\_timing](https://www.postgresql.org/docs/current/runtime-config-statistics.html#RUNTIME-CONFIG-STATISTICS-COLLECTOR) | on | Optional, enables tracking of per-query I/O statistics
+ [track\_io\_timing](https://www.postgresql.org/docs/current/runtime-config-statistics.html#RUNTIME-CONFIG-STATISTICS-COLLECTOR) | 1 | Optional, enables tracking of per-query I/O statistics
 
 ---
 


### PR DESCRIPTION
There is no argument for raising track_activity_query_size in the context of pg_stat_statements these days. This is a historic artifact from the days where pgss kept a limited query text length and tied that to the track_activity_query_size setting (usually used for pg_stat_activity).

Instead, mention track_io_timing as something to adjust, as that will have a direct impact on the usefulness of pg_stat_statements data.