### PR TITLE
Document that SAML is generally available

### DIFF
--- a/accounts/sso/index.mdx
+++ b/accounts/sso/index.mdx
@@ -9,13 +9,10 @@ through a third-party identity provider.
 
 pganalyze integrates with providers such as Okta and Azure AD using [SAML
 2.0](https://en.wikipedia.org/wiki/SAML_2.0). This feature is only available on
-the [Scale Plan](/pricing) and higher.
+the [Scale Plan](/pricing) and higher. Note that the feature is not available
+during a trial.
 
 ## Provider integration
-
-Before continuing with setup, please reach out to [pganalyze
-Support](mailto:support@pganalyze.com) to enable the SSO feature for your
-organization.
 
 If you integrate with Okta, you can follow the [Okta
 integration](/docs/accounts/sso/okta) steps.

--- a/accounts/sso/okta/index.mdx
+++ b/accounts/sso/okta/index.mdx
@@ -18,8 +18,6 @@ Before we go into Okta, we will need access to the SAML settings from pganalyze:
 To retrieve the SAML settings specific to your organization, you can navigate to the **Integrations**
 settings page in your pganalyze account, where you will see the **Single Sign-On with SAML** panel.
 
-If you do not see this panel, the SAML integration is not active on your account. Please reach out to [pganalyze Support](mailto:support@pganalyze.com).
-
 ![Screenshot of pganalyze SAML integration details showing ACS and Metadata URL](../sso_details_for_idp.png)
 
 For Okta we will need the `Single Sign-On URL (ACS)` value.

--- a/accounts/sso/saml2.mdx
+++ b/accounts/sso/saml2.mdx
@@ -21,9 +21,6 @@ To retrieve the SAML settings specific to your organization, you can navigate to
 the **Integrations** settings page in your pganalyze account, where you will see
 the **Single Sign-On with SAML** panel.
 
-If you do not see this panel, the SAML integration is not active on your
-account. Please reach out to [pganalyze Support](mailto:support@pganalyze.com).
-
 ![Screenshot of pganalyze SAML integration details showing ACS and Metadata URL](sso_details_for_idp.png)
 
 **We recommend copying these values directly from the pganalyze app to your


### PR DESCRIPTION
Note that the panel now shows up for everyone on the Integrations tab
of the Settings page, with a note explaining why it is not available
if that's the case, so the documentation has been updated accordingly.
