### PR TITLE
AWS setup: Fix bug in IAM policy for DescribeDBClusters

### DIFF
--- a/install/amazon_rds/03_setup_iam_policy.mdx
+++ b/install/amazon_rds/03_setup_iam_policy.mdx
@@ -42,13 +42,19 @@ To start, go to **[Create IAM policy](https://console.aws.amazon.com/iam/home#/p
         },
         {
             "Action": [
-                "rds:DescribeDBClusters",
                 "rds:DescribeDBInstances",
                 "rds:DownloadDBLogFilePortion",
                 "rds:DescribeDBLogFiles"
             ],
             "Effect": "Allow",
             "Resource": "arn:aws:rds:*:*:db:*"
+        },
+        {
+            "Action": [
+                "rds:DescribeDBClusters"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:rds:*:*:cluster:*"
         }
     ]
 }


### PR DESCRIPTION
We documented this as the permission applying to "db" resources but it should actually be applied to "cluster" resources. This led to IAM permission errors when actually querying an Aurora cluster.