### PR TITLE
Add explicit instructions for Google AlloyDB

### DIFF
--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -406,7 +406,7 @@ Only relevant if you are running your database in Azure using Azure Database for
 
 ## Google Cloud Platform
 
-Only relevant if you are running your database in GCP using Google Cloud SQL. See the <a href="https://pganalyze.com/docs/log-insights/setup/google-cloud-sql">GCP setup instructions</a> for details.
+Only relevant if you are running your database in GCP using Google Cloud SQL or Google AlloyDB. See the <a href="https://pganalyze.com/docs/log-insights/setup/google-cloud-sql">GCP setup instructions</a> for details.
 
 <table>
   <thead>
@@ -419,8 +419,18 @@ Only relevant if you are running your database in GCP using Google Cloud SQL. Se
   <tbody>
     <tr>
       <td>gcp_cloudsql_instance_id (<code>GCP_CLOUDSQL_INSTANCE_ID</code>)</td>
-      <td>n/a, required for Log Insights</td>
+      <td>n/a, required for Log Insights (for Cloud SQL)</td>
       <td>Google Cloud SQL instance ID</td>
+    </tr>
+    <tr>
+      <td>gcp_alloydb_cluster_id (<code>GCP_ALLOYDB_CLUSTER_ID</code>)</td>
+      <td>n/a, required for Log Insights (for AlloyDB)</td>
+      <td>Google AlloyDB cluster ID</td>
+    </tr>
+    <tr>
+      <td>gcp_alloydb_instance_id (<code>GCP_ALLOYDB_INSTANCE_ID</code>)</td>
+      <td>n/a, required for Log Insights (for AlloyDB)</td>
+      <td>Google AlloyDB instance ID (within the given cluster)</td>
     </tr>
     <tr>
       <td>gcp_project_id (<code>GCP_PROJECT_ID</code>)</td>

--- a/components/GCPLogRouting.tsx
+++ b/components/GCPLogRouting.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import TabPanel, { TabItem, TabTextContent } from './TabPanel'
+
+const GCPLogRouting: React.FunctionComponent<{imgCreateLogSink: string}> = ({ imgCreateLogSink }) => {
+  const tabs: TabItem[] = [
+    [ 'cloudsql', 'Google Cloud SQL' ],
+    [ 'alloydb', 'Google AlloyDB' ],
+  ];
+  return (
+    <TabPanel items={tabs}>
+      {(idx: number) => {
+        const id = tabs[idx]?.[0];
+        switch (id) {
+          case 'cloudsql':
+            return <GCPLogRoutingCloudSQL imgCreateLogSink={imgCreateLogSink} />
+          case 'alloydb':
+            return <GCPLogRoutingAlloyDB />
+          default:
+            return null;
+        }
+      }}
+    </TabPanel>
+  )
+}
+
+const GCPLogRoutingCloudSQL: React.FunctionComponent<{imgCreateLogSink: string}> = ({ imgCreateLogSink }) => {
+  return (
+    <TabTextContent>
+      <p>
+        Navigate to your Cloud SQL instance, click on "View PostgreSQL error logs", and then click on "Logs Router".
+      </p>
+      <p>
+        Click "Create Sink", and select your Pub/Sub topic. Make sure that the left side is actually
+        showing PostgreSQL logs (as it does in this screenshot), and that you don't have a different
+        type of resource selected:
+      </p>
+      <p>
+        <img src={imgCreateLogSink} alt="Screenshot of creating a log sink in Google Cloud Console" />
+      </p>
+    </TabTextContent>
+  )
+}
+
+const GCPLogRoutingAlloyDB: React.FunctionComponent = () => {
+  return (
+    <TabTextContent>
+      <p>
+        Navigate to the Logs Router screen under the Logging service. Click "Create Sink" and select your Pub/Sub topic as the destination.
+      </p>
+      <p>
+        To filter for AlloyDB log events, specify an inclusion filter
+        in the following format, replacing <code>MYCLUSTER</code> with your cluster name:
+      </p>
+      <pre>
+        {`resource.type="alloydb.googleapis.com/Instance"
+resource.labels.cluster_id="MYCLUSTER"`}
+      </pre>
+    </TabTextContent>
+  )
+}
+
+export default GCPLogRouting;

--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -363,13 +363,13 @@ function getProviderName(systemType: string): string {
     case 'self_managed':
       return 'your Postgres install';
     case 'amazon_rds':
-      return 'Amazon RDS';
+      return 'Amazon RDS and Amazon Aurora';
     case 'heroku':
       return 'Heroku Postgres';
     case 'google_cloudsql':
-      return 'Google Cloud SQL';
+      return 'Google Cloud SQL and AlloyDB';
     case 'azure_database':
-      return 'Azure Database';
+      return 'Azure Database for PostgreSQL';
     case 'crunchy_bridge':
       return 'Crunchy Bridge';
     case 'aiven':

--- a/directory.json
+++ b/directory.json
@@ -757,7 +757,7 @@
       "path": "/docs/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test"
     },
     "log-insights/setup/google-cloud-sql": {
-      "title": "Log Insights: Setup (Google Cloud SQL)",
+      "title": "Log Insights: Setup (Google Cloud SQL and AlloyDB)",
       "path": "/docs/log-insights/setup/google-cloud-sql"
     },
     "log-insights/setup/google-cloud-sql/01_create_topic_and_subscriber": {

--- a/explain/setup/auto_explain/index.mdx
+++ b/explain/setup/auto_explain/index.mdx
@@ -11,8 +11,8 @@ With our recommended configuration, performance impact is minimal.
 
 Here are the instructions for environments that support `auto_explain`:
 
- * [Amazon RDS & Amazon Aurora](amazon_rds/01_auto_explain_check)
- * [Google Cloud SQL](google_cloud_sql/01_auto_explain_check)
+ * [Amazon RDS and Amazon Aurora](amazon_rds/01_auto_explain_check)
+ * [Google Cloud SQL and AlloyDB](google_cloud_sql/01_auto_explain_check)
  * [Self-Managed Server](self_managed/01_auto_explain_check)
 
 For other environments, we also offer an alternative [log-based Automated EXPLAIN](log_explain) mechanism.

--- a/explain/setup/google_cloud_sql/01_auto_explain_check.mdx
+++ b/explain/setup/google_cloud_sql/01_auto_explain_check.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 1: Check for auto_explain'
-install_track_title: 'Automated EXPLAIN: Setup (Google Cloud SQL)'
+install_track_title: 'Automated EXPLAIN: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/explain/setup
 backlink_title: 'Automated EXPLAIN: Setup'
 ---
@@ -8,7 +8,7 @@ backlink_title: 'Automated EXPLAIN: Setup'
 import GCPStep01InApp from './_01_in_app.mdx'
 import GCPStep01Public from './_01_public.mdx'
 
-The recommended Automated EXPLAIN configuration for Google Cloud SQL is to use
+The recommended Automated EXPLAIN configuration for Google Cloud SQL and AlloyDB is to use
 the Postgres `auto_explain` contrib module. This ensures accurate and detailed plan
 information, including runtime information (as gathered by EXPLAIN ANALYZE). With our
 recommended configuration (presented in a later step), performance overhead is minimal.

--- a/explain/setup/google_cloud_sql/02_enable_auto_explain.mdx
+++ b/explain/setup/google_cloud_sql/02_enable_auto_explain.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 2: Enable auto_explain'
-install_track_title: 'Automated EXPLAIN: Setup (Google Cloud SQL)'
+install_track_title: 'Automated EXPLAIN: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/explain/setup
 backlink_title: 'Automated EXPLAIN: Setup'
 ---

--- a/explain/setup/google_cloud_sql/03_review_settings.mdx
+++ b/explain/setup/google_cloud_sql/03_review_settings.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 3: Review auto_explain settings'
-install_track_title: 'Automated EXPLAIN: Setup (Google Cloud SQL)'
+install_track_title: 'Automated EXPLAIN: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/explain/setup
 backlink_title: 'Automated EXPLAIN: Setup'
 ---
@@ -9,7 +9,7 @@ import PgSettingsRecommendations, { getAutoExplainSettingRecommendations } from 
 
 import imgGcpAutoExplainSettings from '../../../images/gcp_auto_explain_settings.png'
 
-export const ImgGCPAutoExplainSettings = () => <img src={imgGcpAutoExplainSettings} alt="Configure auto_explain for your Google Cloud SQL database" />
+export const ImgGCPAutoExplainSettings = () => <img src={imgGcpAutoExplainSettings} alt="Configure auto_explain for your Google Cloud SQL / AlloyDB database" />
 
 export const AutoExplainLink = ({version, children}) => {
   return (
@@ -27,7 +27,7 @@ but we've found the following is a good starting point:
 
 <PgSettingsRecommendations recommendations={getAutoExplainSettingRecommendations(props.settings)} />
 
-Apply the settings above as Google Cloud SQL flags for your database:
+Apply the settings above as Google Cloud SQL / AlloyDB flags for your database:
 
 <ImgGCPAutoExplainSettings />
 

--- a/explain/setup/google_cloud_sql/04_test_and_verify.mdx
+++ b/explain/setup/google_cloud_sql/04_test_and_verify.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 4: Test and Verify'
-install_track_title: 'Automated EXPLAIN: Setup (Google Cloud SQL)'
+install_track_title: 'Automated EXPLAIN: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/explain/setup
 backlink_title: 'Automated EXPLAIN: Setup'
 ---

--- a/explain/setup/google_cloud_sql/_01_public.mdx
+++ b/explain/setup/google_cloud_sql/_01_public.mdx
@@ -3,7 +3,7 @@ import AutoExplainNotice from '../_auto_explain_notice.mdx'
 # Check if auto_explain already enabled
 
 First, to check if `auto_explain` is already enabled on your system, run the following
-query as user with the `cloudsqlsuperuser` role:
+query as user with the `cloudsqlsuperuser` / `alloydbsuperuser` role:
 
 ```sql
 SELECT setting, pending_restart FROM pg_settings WHERE name = 'shared_preload_libraries';

--- a/explain/setup/google_cloud_sql/_02_actually_enable.mdx
+++ b/explain/setup/google_cloud_sql/_02_actually_enable.mdx
@@ -1,11 +1,11 @@
 import gcpEnableAutoExplain from '../../../images/gcp_enable_auto_explain.png'
 
-export const ImgGCPEnableAutoExplain = () => <img src={gcpEnableAutoExplain} alt="Enable auto_explain for your Google Cloud SQL database" />
+export const ImgGCPEnableAutoExplain = () => <img src={gcpEnableAutoExplain} alt="Enable auto_explain for your Google Cloud SQL / AlloyDB database" />
 
 To enable `auto_explain`, you will need to go to click "EDIT" on top of the Overview page
-for your database, scroll down to the Flags section, and turn on the `cloudsql.enable_auto_explain`
+for your database, scroll down to the Flags section, and turn on the `cloudsql.enable_auto_explain` / `alloydb.enable_auto_explain`
 flag. This will add `auto_explain` to the Postgres `shared_preload_libraries` setting (you cannot
-modify this directly on Google Cloud SQL):
+modify this directly on Google Cloud SQL / AlloyDB):
 
 <ImgGCPEnableAutoExplain />
 

--- a/explain/setup/index.mdx
+++ b/explain/setup/index.mdx
@@ -30,17 +30,17 @@ Log-based EXPLAIN is not guaranteed to show the same plan that was executed, and
 
 ### Supported platforms
 
-Platform         | Log-based EXPLAIN |    auto_explain   |
------------------|-------------------|-------------------|
-Amazon RDS       | Yes               | Yes (Recommended) |
-Azure Database   | Yes               | No                |
-Google Cloud SQL | Yes               | Yes (Recommended) |
-Heroku Postgres  | Yes               | No                |
-Crunchy Bridge   | Yes               | No                |
-Aiven            | Yes               | No                |
-Self-managed VM  | Yes               | Yes (Recommended) |
-Kubernetes       | No                | No                |
-Other PaaS       | Contact support   | Contact support   |
+Platform                      | Log-based EXPLAIN |    auto_explain   |
+------------------------------|-------------------|-------------------|
+Amazon RDS and Amazon Aurora  | Yes               | Yes (Recommended) |
+Azure Database for PostgreSQL | Yes               | No                |
+Google Cloud SQL and AlloyDB  | Yes               | Yes (Recommended) |
+Heroku Postgres               | Yes               | No                |
+Crunchy Bridge                | Yes               | No                |
+Aiven                         | Yes               | No                |
+Self-managed VM               | Yes               | Yes (Recommended) |
+Kubernetes                    | No                | No                |
+Other PaaS                    | Contact support   | Contact support   |
 
 We are constantly evaluating new platform to support - please [reach out](/contact) if you're missing an integration, to help us prioritize.
 
@@ -51,7 +51,7 @@ See the following pages for details on how to install pganalyze Automated EXPLAI
 
 * [Amazon RDS & Amazon Aurora](/docs/explain/setup/amazon_rds/01_auto_explain_check)
 * [Azure Database for PostgreSQL](/docs/explain/setup/log_explain/01_create_helper_functions)
-* [Google Cloud SQL](/docs/explain/setup/google_cloud_sql/01_auto_explain_check)
+* [Google Cloud SQL and AlloyDB](/docs/explain/setup/google_cloud_sql/01_auto_explain_check)
 * [Heroku Postgres](/docs/explain/setup/heroku/01_enable_log_explain)
 * [Crunchy Bridge](/docs/explain/setup/crunchy_bridge/01_create_helper_functions)
 * [Aiven](/docs/explain/setup/log_explain/01_create_helper_functions)

--- a/index.mdx
+++ b/index.mdx
@@ -9,7 +9,7 @@ title: 'Documentation'
   - Environment-specific guides
     - [Amazon RDS and Amazon Aurora](/docs/install/amazon_rds/01_configure_rds_instance)
     - [Azure Database for PostgreSQL](/docs/install/azure_database/01_create_monitoring_user)
-    - [Google Cloud SQL](/docs/install/google_cloud_sql/01_create_monitoring_user)
+    - [Google Cloud SQL and AlloyDB](/docs/install/google_cloud_sql/01_create_monitoring_user)
     - [Heroku Postgres](/docs/install/heroku_postgres/01_deploy_the_collector)
     - [Crunchy Bridge](/docs/install/crunchy_bridge/01_deploy_the_collector)
     - [Self-managed (and other hosted Postgres)](/docs/install/self_managed/00_choose_setup_method)

--- a/install.mdx
+++ b/install.mdx
@@ -83,14 +83,14 @@ To continue please select in which environment you are running your Postgres dat
       src={imgLogoAzure}
       style={{ padding: "5px" }}
     />
-    Azure Database
+    Azure Database for PostgreSQL
   </Link>
   <Link
     className={styles.installChoiceStep}
     to="install/google_cloud_sql/01_create_monitoring_user"
   >
     <img src={imgLogoGcp} />
-    Google Cloud SQL
+    Google Cloud SQL and AlloyDB
   </Link>
 </div>
 

--- a/install/google_cloud_sql/01_create_monitoring_user.mdx
+++ b/install/google_cloud_sql/01_create_monitoring_user.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 1: Create Monitoring User'
-install_track_title: Installation Guide (Google Cloud SQL)
+install_track_title: Installation Guide (Google Cloud SQL and AlloyDB)
 backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---

--- a/install/google_cloud_sql/02_install_the_collector.mdx
+++ b/install/google_cloud_sql/02_install_the_collector.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 2: Install the Collector'
-install_track_title: Installation Guide (Google Cloud SQL)
+install_track_title: Installation Guide (Google Cloud SQL and AlloyDB)
 backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
@@ -36,6 +36,6 @@ export const SelectCollectorPlatform = () => {
 
 To continue, we need to know where you'd like to install the pganalyze collector.
 
-The collector needs to run on a virtual machine or container and be able to reach your Google Cloud SQL database:
+The collector needs to run on a virtual machine or container and be able to reach your Google Cloud SQL or AlloyDB database:
 
 <SelectCollectorPlatform />

--- a/install/google_cloud_sql/02_install_the_collector_deb.mdx
+++ b/install/google_cloud_sql/02_install_the_collector_deb.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 2: Install the Collector'
-install_track_title: Installation Guide (Google Cloud SQL)
+install_track_title: Installation Guide (Google Cloud SQL and AlloyDB)
 backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---

--- a/install/google_cloud_sql/02_install_the_collector_docker.mdx
+++ b/install/google_cloud_sql/02_install_the_collector_docker.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 2: Install the Collector'
-install_track_title: Installation Guide (Google Cloud SQL)
+install_track_title: Installation Guide (Google Cloud SQL and AlloyDB)
 backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---

--- a/install/google_cloud_sql/02_install_the_collector_yum.mdx
+++ b/install/google_cloud_sql/02_install_the_collector_yum.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 2: Install the Collector'
-install_track_title: Installation Guide (Google Cloud SQL)
+install_track_title: Installation Guide (Google Cloud SQL and AlloyDB)
 backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---

--- a/install/google_cloud_sql/03_configure_the_collector.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 3: Configure the Collector'
-install_track_title: Installation Guide (Google Cloud SQL)
+install_track_title: Installation Guide (Google Cloud SQL and AlloyDB)
 backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---

--- a/install/google_cloud_sql/03_configure_the_collector_docker.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector_docker.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 3: Configure the Collector'
-install_track_title: Installation Guide (Google Cloud SQL)
+install_track_title: Installation Guide (Google Cloud SQL and AlloyDB)
 backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
@@ -44,11 +44,15 @@ Create your configuration file (e.g. named `pganalyze_collector.env`) with envir
 Fill in the values step-by-step:
 
 1. <APIKeyInstructions apiKey={props.apiKey} />
-2. The `DB_HOST` is the IP address of your Google Cloud SQL instance
-3. The `DB_NAME` is the database on the Google Cloud SQL instance you want to monitor
+2. The `DB_HOST` is the IP address of your Google Cloud SQL / AlloyDB instance
+3. The `DB_NAME` is the database on the Google Cloud SQL / AlloyDB instance you want to monitor
 4. The `DB_USERNAME` and `DB_PASSWORD` should be the credentials of the monitoring user we created in Step 1
-5. The `GCP_PROJECT_ID` should match the name of the GCP project that contains your Cloud SQL instance
-6. The `GCP_CLOUDSQL_INSTANCE_ID` should match the name of the Cloud SQL instance
+5. The `GCP_PROJECT_ID` should match the name of the GCP project that contains your Cloud SQL / AlloyDB instance
+6. The `GCP_CLOUDSQL_INSTANCE_ID` should match the name of the Cloud SQL instance - if using AlloyDB see below
+
+## Instructions for Google AlloyDB
+
+If you are using Google AlloyDB, do not specify `GCP_CLOUDSQL_INSTANCE_ID`, but instead specify `GCP_ALLOYDB_CLUSTER_ID` (set to the name of the cluster) and `GCP_ALLOYDB_INSTANCE_ID` (set to the instance name within the cluster).
 
 ## Test snapshot
 

--- a/install/google_cloud_sql/03_configure_the_collector_package.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector_package.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 3: Configure the Collector'
-install_track_title: Installation Guide (Google Cloud SQL)
+install_track_title: Installation Guide (Google Cloud SQL and AlloyDB)
 backlink_href: /docs/install
 backlink_title: 'Installation Guide'
 ---
@@ -46,11 +46,15 @@ The collector configuration file lives in `/etc/pganalyze-collector.conf`, and l
 Fill in the values step-by-step:
 
 1. <APIKeyInstructions apiKey={props.apiKey} />
-2. The `db_host` is the IP address of your Google Cloud SQL instance
-3. The `db_name` is the database on the Google Cloud SQL instance you want to monitor
+2. The `db_host` is the IP address of your Google Cloud SQL / AlloyDB instance
+3. The `db_name` is the database on the Google Cloud SQL / AlloyDB instance you want to monitor
 4. The `db_username` and `db_password` should be the credentials of the monitoring user we created in Step 1
-5. The `gcp_project_id` should match the name of the GCP project that contains your Cloud SQL instance
-6. The `gcp_cloudsql_instance_id` should match the name of the Cloud SQL instance
+5. The `gcp_project_id` should match the name of the GCP project that contains your Cloud SQL / AlloyDB instance
+6. The `gcp_cloudsql_instance_id` should match the name of the Cloud SQL instance - if using AlloyDB see below
+
+## Instructions for Google AlloyDB
+
+If you are using Google AlloyDB, do not specify `gcp_cloudsql_instance_id`, but instead specify `gcp_alloydb_cluster_id` (set to the name of the cluster) and `gcp_alloydb_instance_id` (set to the instance name within the cluster).
 
 ## Testing the new configuration
 

--- a/install/google_cloud_sql/_01_create_monitoring_user.mdx
+++ b/install/google_cloud_sql/_01_create_monitoring_user.mdx
@@ -10,7 +10,7 @@ We recommend creating a separate monitoring user on your PostgreSQL database for
 
 ## Enabling pg_stat_statements
 
-Connect to your database with **cloudsqlsuperuser privileges** (i.e. the initial user that was created on instance creation), e.g. using `psql`.
+Connect to your database with **cloudsqlsuperuser / alloydbsuperuser** privileges (i.e. the initial user that was created on instance creation), e.g. using `psql`.
 
 Run the following SQL commands to enable the `pg_stat_statements` extension, and make sure it was installed correctly:
 
@@ -21,13 +21,13 @@ SELECT * FROM pg_stat_statements LIMIT 1;
 
 ## Create monitoring user
 
-Connect to the database you will be monitoring, again as a user with **cloudsqlsuperuser privileges**.
+Connect to the database you will be monitoring, again as a user with **cloudsqlsuperuser / alloydbsuperuser** privileges.
 Then run the following to create a monitoring user (we've generated a random password for you, but you
 can replace it with one of your choosing):
 
 <MonitoringUserSetupInstructions minPostgres={100000} password={props.password} />
 
-Note that it is important you run these as a user with **cloudsqlsuperuser privileges** in order to pass down the full access to statistics tables.
+Note that it is important you run these as a user with **cloudsqlsuperuser / alloydbsuperuser** privileges in order to pass down the full access to statistics tables.
 
 ## Verify connection
 

--- a/log-insights/index.mdx
+++ b/log-insights/index.mdx
@@ -14,9 +14,9 @@ or to explain why your database might be slow at a given moment.
 
 To start, follow the platform-specific setup steps:
 
-* [Amazon RDS & Amazon Aurora](/docs/log-insights/setup/amazon-rds/01_test_log_download)
+* [Amazon RDS and Amazon Aurora](/docs/log-insights/setup/amazon-rds/01_test_log_download)
 * [Azure Database for PostgreSQL](/docs/log-insights/setup/azure-database/01_set_up_managed_identity)
-* [Google Cloud SQL](/docs/log-insights/setup/google-cloud-sql/01_create_topic_and_subscriber)
+* [Google Cloud SQL and AlloyDB](/docs/log-insights/setup/google-cloud-sql/01_create_topic_and_subscriber)
 * [Heroku Postgres](/docs/log-insights/setup/heroku-postgres/01_add_log_drain)
 * [Crunchy Bridge](/docs/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test)
 * [Aiven](/docs/log-insights/setup/aiven/01_move_database_into_vpc)

--- a/log-insights/setup/google-cloud-sql/01_create_topic_and_subscriber.mdx
+++ b/log-insights/setup/google-cloud-sql/01_create_topic_and_subscriber.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Step 1: Create Topic and Subscriber'
-install_track_title: 'Log Insights: Setup (Google Cloud SQL)'
+install_track_title: 'Log Insights: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/log-insights/setup
 backlink_title: 'Log Insights: Setup'
 ---
 
-Log output on Google Cloud SQL is available through Cloud Pub/Sub.
+Log output on Google Cloud SQL / AlloyDB is available through Cloud Pub/Sub.
 
 In the Google Cloud Console, navigate to "Pub/Sub" and create a new Topic, e.g. calling it "postgres-logs".
 

--- a/log-insights/setup/google-cloud-sql/02_configure_log_routing.mdx
+++ b/log-insights/setup/google-cloud-sql/02_configure_log_routing.mdx
@@ -1,23 +1,16 @@
 ---
 title: 'Step 2: Configure Log Routing'
-install_track_title: 'Log Insights: Setup (Google Cloud SQL)'
+install_track_title: 'Log Insights: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/log-insights/setup
 backlink_title: 'Log Insights: Setup'
 ---
 
 import imgCreateLogSink from './create-log-sink.png'
+import GCPLogRouting from '../../../components/GCPLogRouting'
 
-export const ImgCreateLogSink = () => <img src={imgCreateLogSink} alt="Screenshot of creating a log sink in Google Cloud Console" />
+<GCPLogRouting imgCreateLogSink={imgCreateLogSink} />
 
-Navigate to your Cloud SQL database instance, click on "View PostgreSQL error logs", and then click on "Logs Router".
-
-Click "Create Sink", and select your Pub/Sub topic. Make sure that the left side is actually
-showing PostgreSQL logs (as it does in this screenshot), and that you don't have a different
-type of resource selected:
-
-<ImgCreateLogSink />
-
-Now we need to create a service account that can access the logs sent to the Pub/Sub topic.
+After you've saved the new sink, we now need to create a service account that can access the logs sent to the Pub/Sub topic.
 
 <Link className="btn btn-success" to="03_set_up_service_account">
   Continue to Step 3: Set up Service Account

--- a/log-insights/setup/google-cloud-sql/03_set_up_service_account.mdx
+++ b/log-insights/setup/google-cloud-sql/03_set_up_service_account.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 3: Set Up Service Account'
-install_track_title: 'Log Insights: Setup (Google Cloud SQL)'
+install_track_title: 'Log Insights: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/log-insights/setup
 backlink_title: 'Log Insights: Setup'
 ---

--- a/log-insights/setup/google-cloud-sql/04_configure_collector.mdx
+++ b/log-insights/setup/google-cloud-sql/04_configure_collector.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Step 4: Configure Collector'
-install_track_title: 'Log Insights: Setup (Google Cloud SQL)'
+install_track_title: 'Log Insights: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/log-insights/setup
 backlink_title: 'Log Insights: Setup'
 ---
@@ -16,7 +16,7 @@ Next, update the collector configuration for this server.
 
 The value for the setting should be set to the "Subscription name" you can see when clicking on the details for the Pub/Sub subscriber we created earlier.
 
-<CollectorLogTest provider="Google Cloud SQL" configFromEnv={props.configFromEnv} />
+<CollectorLogTest provider="Google Cloud SQL and AlloyDB" configFromEnv={props.configFromEnv} />
 
 For additional help when you get an error please check our
 [troubleshooting documentation](https://pganalyze.com/docs/log-insights/setup/google-cloud-sql/troubleshooting).

--- a/log-insights/setup/google-cloud-sql/index.mdx
+++ b/log-insights/setup/google-cloud-sql/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Log Insights: Setup (Google Cloud SQL)'
-install_track_title: 'Log Insights: Setup (Google Cloud SQL)'
+title: 'Log Insights: Setup (Google Cloud SQL and AlloyDB)'
+install_track_title: 'Log Insights: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/log-insights/setup
 backlink_title: 'Log Insights: Setup'
 ---

--- a/log-insights/setup/google-cloud-sql/troubleshooting.mdx
+++ b/log-insights/setup/google-cloud-sql/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Troubleshooting'
-install_track_title: 'Log Insights: Setup (Google Cloud SQL)'
+install_track_title: 'Log Insights: Setup (Google Cloud SQL and AlloyDB)'
 backlink_href: /docs/log-insights/setup
 backlink_title: 'Log Insights: Setup'
 ---

--- a/log-insights/setup/index.mdx
+++ b/log-insights/setup/index.mdx
@@ -14,9 +14,9 @@ to [rate limits](/docs/log-insights/limits) for incoming log data.
 
 See the following pages for details on how to install pganalyze Log Insights:
 
-* [Amazon RDS & Amazon Aurora](/docs/log-insights/setup/amazon-rds/01_test_log_download)
+* [Amazon RDS and Amazon Aurora](/docs/log-insights/setup/amazon-rds/01_test_log_download)
 * [Azure Database for PostgreSQL](/docs/log-insights/setup/azure-database/01_set_up_managed_identity)
-* [Google Cloud SQL](/docs/log-insights/setup/google-cloud-sql/01_create_topic_and_subscriber)
+* [Google Cloud SQL and AlloyDB](/docs/log-insights/setup/google-cloud-sql/01_create_topic_and_subscriber)
 * [Heroku Postgres](/docs/log-insights/setup/heroku-postgres/01_add_log_drain)
 * [Crunchy Bridge](/docs/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test)
 * [Aiven](/docs/log-insights/setup/aiven/01_move_database_into_vpc)
@@ -26,5 +26,5 @@ See the following pages for details on how to install pganalyze Log Insights:
 For troubleshooting instructions, check the following pages:
 
 * [Azure Database for PostgreSQL](/docs/log-insights/setup/azure-database/troubleshooting)
-* [Google Cloud SQL](/docs/log-insights/setup/google-cloud-sql/troubleshooting)
+* [Google Cloud SQL and AlloyDB](/docs/log-insights/setup/google-cloud-sql/troubleshooting)
 * [Self-Managed Server](/docs/log-insights/setup/self-managed/troubleshooting)


### PR DESCRIPTION
We've added support in the collector, but had not yet documented that our Google Cloud SQL instructions also work for AlloyDB, apart from a few minor details that this change now clarifies.

In passing this makes sure we use "Amazon RDS and Amazon Aurora" consistently, and adds the "for PostgreSQL" suffix to "Azure Database" where it was missing (note we technically also support Azure CosmosDB for PostgreSQL, but we omit this for now due to formatting challenges.