### PR TITLE
Install overview: Fix styling for Self-Managed secondary title

### DIFF
--- a/install.mdx
+++ b/install.mdx
@@ -33,7 +33,9 @@ To continue please select in which environment you are running your Postgres dat
     to="install/self_managed/00_choose_setup_method"
   >
     <img src={imgLogoPgsql} />
-    Self-Managed
+    <p>
+      Self-Managed
+    </p>
     <small style={{ marginTop: "-15px", fontSize: "12px" }}>
       VM / Container / On-Premise
     </small>


### PR DESCRIPTION
Previously this was different between the in-app rendering and the website docs rendering, because the in-app renderer adds an implicit p tag around the panel text (such as "Self-Managed"), but the website does not. Generally this doesn't matter, but in the case of the self-managed panel it caused a styling difference on the website.

---

Before:

<img width="831" alt="Screen Shot 2022-12-02 at 5 04 06 PM" src="https://user-images.githubusercontent.com/7227/205414891-01eca579-aa12-4088-b495-9eb47038ccfd.png">

After:
<img width="802" alt="Screen Shot 2022-12-02 at 5 03 53 PM" src="https://user-images.githubusercontent.com/7227/205414898-dcbed32f-8938-414f-ac9f-2ea5059f7346.png">

