### PR TITLE
Document `always_collect_system_data` field

### DIFF
--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -477,6 +477,13 @@ a self-managed VM on a cloud provider, the configuration settings here may be us
       <td>local address (host:port) to listen on for syslog messages
         (see <a href="/docs/log-insights/setup/syslog-server">syslog server instructions</a>)</td>
     </tr>
+    <tr>
+      <td>always_collect_system_data (<code>PGA_ALWAYS_COLLECT_SYSTEM_DATA</code>)</td>
+      <td>false</td>
+      <td>Always gather local system metrics, regardless of whether the database address is local or
+          remote. This is useful for setups which connect to a local database with a non-local IP
+          address.</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Added in pganalyze/collector#341. Documents the option under the 'Self-managed servers' section on the collector settings page.