### PR TITLE
Include DB_ALL_NAMES=1 in Crunchy setup steps

### DIFF
--- a/install/crunchy_bridge/01_deploy_the_collector.mdx
+++ b/install/crunchy_bridge/01_deploy_the_collector.mdx
@@ -11,7 +11,7 @@ import { MonitoringUserColumnStats, MonitoringUserLogRead } from "../../componen
 export const CollectorStartCommand = ({ apiKey, cmd, logExplain }) => {
   return (
     <CodeBlock>
-      {`SELECT run_container('` + (cmd ? '' : '-d ') + `-t -e DB_URL="REPLACE_ME" -e PGA_API_KEY="` + (apiKey ? apiKey : 'API_KEY') + '"' + (logExplain ? ' -e PGA_ENABLE_LOG_EXPLAIN=true' : '') + ` DB_ALL_NAMES=1 quay.io/pganalyze/collector:stable` + (cmd ? ` ${cmd}` : '') + `');`}
+      {`SELECT run_container('` + (cmd ? '' : '-d ') + `-t -e DB_URL="REPLACE_ME" -e PGA_API_KEY="` + (apiKey ? apiKey : 'API_KEY') + '"' + (logExplain ? ' -e PGA_ENABLE_LOG_EXPLAIN=true' : '') + ` -e DB_ALL_NAMES=1 quay.io/pganalyze/collector:stable` + (cmd ? ` ${cmd}` : '') + `');`}
     </CodeBlock>
   );
 };

--- a/install/crunchy_bridge/01_deploy_the_collector.mdx
+++ b/install/crunchy_bridge/01_deploy_the_collector.mdx
@@ -11,7 +11,7 @@ import { MonitoringUserColumnStats, MonitoringUserLogRead } from "../../componen
 export const CollectorStartCommand = ({ apiKey, cmd, logExplain }) => {
   return (
     <CodeBlock>
-      {`SELECT run_container('` + (cmd ? '' : '-d ') + `-t -e DB_URL="REPLACE_ME" -e PGA_API_KEY="` + (apiKey ? apiKey : 'API_KEY') + '"' + (logExplain ? ' -e PGA_ENABLE_LOG_EXPLAIN=true' : '') + ` quay.io/pganalyze/collector:stable` + (cmd ? ` ${cmd}` : '') + `');`}
+      {`SELECT run_container('` + (cmd ? '' : '-d ') + `-t -e DB_URL="REPLACE_ME" -e PGA_API_KEY="` + (apiKey ? apiKey : 'API_KEY') + '"' + (logExplain ? ' -e PGA_ENABLE_LOG_EXPLAIN=true' : '') + ` DB_ALL_NAMES=1 quay.io/pganalyze/collector:stable` + (cmd ? ` ${cmd}` : '') + `');`}
     </CodeBlock>
   );
 };


### PR DESCRIPTION
The default steps for Crunchy can result in only the `postgres` database being tracked, so instead this PR defaults Crunchy users to track all databases to simplify setup.

https://pganalyze.slack.com/archives/C027W74E7KP/p1675439427888259