### PR TITLE
Enterprise setup docs: Add missing /docs/ prefix to link URL

### DIFF
--- a/enterprise/setup/index.mdx
+++ b/enterprise/setup/index.mdx
@@ -62,7 +62,7 @@ LICENSE_KEY=KEYKEYKEY
 
 If you'd like to use the Log Insights or Automated EXPLAIN features, or want to run the collector separately from the Enterprise Server container, you also need to pass the [object storage configuration](/docs/enterprise/setup/object-storage) here.
 
-You can find the full explanation of all variables in the [settings documentation](/enterprise/settings).
+You can find the full explanation of all variables in the [settings documentation](/docs/enterprise/settings).
 
 
 ### Step 3: Initialize Database & Verify Installation


### PR DESCRIPTION
This was 404ing by accident, confusing those who were trying to follow the documentation.