### PR TITLE
Collector settings: Use "=" instead of ":" to separate key values

### DIFF
--- a/components/CollectorSettings.tsx
+++ b/components/CollectorSettings.tsx
@@ -8,7 +8,7 @@ const CollectorSettings: React.FunctionComponent<{settings: CollectorSetting[], 
     return (
       <div>
         <p>
-          If using the config file, make the following changes to your <code>pganalyze-collector.conf</code>:
+          If using the config file, make the following changes, typically in <code>/etc/pganalyze-collector.conf</code>:
         </p>
         <CollectorConfigFileSettings settings={settings} />
         <p>
@@ -41,7 +41,7 @@ const CollectorConfigFileSettings: React.FunctionComponent<{settings: CollectorS
   return (
     <CodeBlock>
       {settings.map(([setting, value]) => {
-        return `${setting}: ${value}`
+        return `${setting} = ${value}`
       }).join("\n")}
     </CodeBlock>
   )


### PR DESCRIPTION
This is how we typically show other config examples, as well as the example config file that's installed with the packages.

In passing, clarify that the file is located at /etc/pganalyze-collector.conf (not just "pganalyze-collector.conf") which has been a confusion for some users, and in 99% of the cases this is the correct location.