### PR TITLE
Update monitoring user setup instructions

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -1,41 +1,21 @@
 import React from "react";
 
 import { useCodeBlock } from "./CodeBlock";
-import TabPanel, { TabItem } from './TabPanel'
 
 type Props = {
-  minPostgres: number;
   password: string;
   adminUsername?: string;
   noPgMonitor?: boolean;
 };
 
 const MonitoringUserSetupInstructions: React.FunctionComponent<Props> = ({
-  minPostgres = 90600,
   password = 'mypassword',
   adminUsername,
   noPgMonitor
 }) => {
-  type SetupOpt = [
-    id: string,
-    version: number,
-    label: string,
-    instructions: React.ComponentType<{password: string, noPgMonitor?: boolean, adminUsername?: string}>
-  ];
-  const opts: SetupOpt[] = [
-    [ 'monitoring_user_10', 100000, 'PostgreSQL 10+', MonitoringUser10 ],
-    [ 'monitoring_user_96', 90600, 'PostgreSQL 9.6', MonitoringUser96 ],
-  ].filter(([_id, version, _label ]) => minPostgres <= version) as SetupOpt[];
-
-  const tabs = opts.map<TabItem>(opt => [opt[0], opt[2]])
   return (
     <>
-      <TabPanel items={tabs}>
-        {(idx: number) => {
-          const ActiveTab = opts[idx][3];
-          return <ActiveTab password={password} noPgMonitor={noPgMonitor} />
-        }}
-      </TabPanel>
+      <MonitoringUserBase password={password} noPgMonitor={noPgMonitor} />
       <MonitoringUserColumnStats username="pganalyze" adminUsername={adminUsername} />
     </>
   );
@@ -153,7 +133,7 @@ $$ LANGUAGE plpgsql VOLATILE SECURITY DEFINER;`}
   );
 }
 
-const MonitoringUser10: React.FunctionComponent<{
+const MonitoringUserBase: React.FunctionComponent<{
   password: string;
   noPgMonitor?: boolean;
 }> = ({password, noPgMonitor}) => {
@@ -172,52 +152,8 @@ $$
   /* pganalyze-collector */ SELECT * FROM pg_catalog.pg_stat_replication;
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
       </CodeBlock>
-    </>
-  )
-}
-
-const MonitoringUser96: React.FunctionComponent<{password: string}> = ({password}) => {
-  const CodeBlock = useCodeBlock();
-  return (
-    <>
-      <CodeBlock>
-        {`CREATE USER pganalyze WITH PASSWORD '${password}' CONNECTION LIMIT 5;
-
-CREATE SCHEMA pganalyze;
-GRANT USAGE ON SCHEMA pganalyze TO pganalyze;
-GRANT USAGE ON SCHEMA public TO pganalyze;
-
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
-
-CREATE OR REPLACE FUNCTION pganalyze.get_stat_statements(showtext boolean = true) RETURNS SETOF pg_stat_statements AS
-$$
-  /* pganalyze-collector */ SELECT * FROM public.pg_stat_statements(showtext);
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
-
-CREATE OR REPLACE FUNCTION pganalyze.get_stat_activity() RETURNS SETOF pg_stat_activity AS
-$$
-  /* pganalyze-collector */ SELECT * FROM pg_catalog.pg_stat_activity;
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
-
-CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
-$$
-  /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
-  n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
-  most_common_elem_freqs, elem_count_histogram
-  FROM pg_catalog.pg_stats;
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
-
-CREATE OR REPLACE FUNCTION pganalyze.get_stat_replication() RETURNS SETOF pg_stat_replication AS
-$$
-  /* pganalyze-collector */ SELECT * FROM pg_catalog.pg_stat_replication;
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
-
-CREATE OR REPLACE FUNCTION pganalyze.get_stat_progress_vacuum() RETURNS SETOF pg_stat_progress_vacuum AS
-$$
-  /* pganalyze-collector */ SELECT * FROM pg_catalog.pg_stat_progress_vacuum;
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}</CodeBlock>
       <p>
-        If you enabled the optional reset mode (usually not required), you will also need this helper method:
+        If you enable the optional reset mode (usually not required), you will also need this helper method:
       </p>
       <CodeBlock>
       {`CREATE OR REPLACE FUNCTION pganalyze.reset_stat_statements() RETURNS SETOF void AS

--- a/install/aiven/_01_create_monitoring_user.mdx
+++ b/install/aiven/_01_create_monitoring_user.mdx
@@ -6,7 +6,7 @@ Connect to the database you will be monitoring as the **avnadmin user**.
 Then run the following to create a new user (we've generated a random password for you, but you
 can replace it with one of your choosing):
 
-<MonitoringUserSetupInstructions password={props.password} adminUsername='avnadmin' minPostgres={100000} noPgMonitor />
+<MonitoringUserSetupInstructions password={props.password} adminUsername='avnadmin' noPgMonitor />
 
 Note that it is important you run these as the **avnadmin user** in order to
 pass down the full access to statistics tables.

--- a/install/azure_database/_02_create_monitoring_user.mdx
+++ b/install/azure_database/_02_create_monitoring_user.mdx
@@ -12,7 +12,7 @@ As a user with **azure_pg_admin privileges**, connect to the database you will b
 and run the following to create a new user (we've generated a random password for you, but you
 can replace it with one of your choosing):
 
-<MonitoringUserSetupInstructions minPostgres={90500} password={props.password} />
+<MonitoringUserSetupInstructions password={props.password} />
 
 Note that it is important you run these as the Postgres superuser in order to pass down the full access to statistics tables.
 

--- a/install/google_cloud_sql/_01_create_monitoring_user.mdx
+++ b/install/google_cloud_sql/_01_create_monitoring_user.mdx
@@ -25,7 +25,7 @@ Connect to the database you will be monitoring, again as a user with **cloudsqls
 Then run the following to create a monitoring user (we've generated a random password for you, but you
 can replace it with one of your choosing):
 
-<MonitoringUserSetupInstructions minPostgres={100000} password={props.password} />
+<MonitoringUserSetupInstructions password={props.password} />
 
 Note that it is important you run these as a user with **cloudsqlsuperuser / alloydbsuperuser** privileges in order to pass down the full access to statistics tables.
 


### PR DESCRIPTION
 - drop 9.6 instructions (since we've dropped 9.6 support)
 - drop the minPostgres flag to the MonitoringUserSetupInstructions
   component since instructions are now uniform
 - use the pre-pg_monitor instructions for pg_stat_statements_reset
   on current versions, since this is not actually included in
   pg_monitor permissions

Regarding the last point, our docs implied that pg_monitor grants the
ability to call pg_stat_statements_reset(), but I'm not sure when that
would have been in effect. The role was new as of 10, losing that
ability doesn't seem to be mentioned in the 11.0, 12.0, or 13.0
release notes, and it doesn't seem to work in the 10, 14, or 15 that I
have installed locally.
