### PR TITLE
Enterprise docs: Fix RDS policy, remove CORS settings

### DIFF
--- a/enterprise/setup/kubernetes_amazon_eks.mdx
+++ b/enterprise/setup/kubernetes_amazon_eks.mdx
@@ -136,7 +136,6 @@ And second, create the policy that permits access to Amazon RDS instances you wa
     "Statement": [
         {
             "Action": [
-                "rds:DescribeDBInstances",
                 "cloudwatch:GetMetricStatistics"
             ],
             "Effect": "Allow",
@@ -158,11 +157,19 @@ And second, create the policy that permits access to Amazon RDS instances you wa
         },
         {
             "Action": [
+                "rds:DescribeDBInstances",
                 "rds:DownloadDBLogFilePortion",
                 "rds:DescribeDBLogFiles"
             ],
             "Effect": "Allow",
             "Resource": "arn:aws:rds:*:*:db:*"
+        },
+        {
+            "Action": [
+                "rds:DescribeDBClusters"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:rds:*:*:cluster:*"
         }
     ]
 }

--- a/enterprise/setup/object-storage-s3.mdx
+++ b/enterprise/setup/object-storage-s3.mdx
@@ -62,33 +62,7 @@ The pganalyze Docker container needs to have authenticated access to the S3 buck
 
 You will also need to assign this IAM user as a "Key User" to the KMS key.
 
-## 3. S3 bucket retention policy and CORS settings
-
-Please ensure that S3 buckets don't have public access enabled. All S3 objects created by pganalyze are created as private only.
-
-To avoid keeping data forever, we recommend configuring the S3 buckets to expire objects after 35 days using [lifecycle rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html).
-
-For the logs S3 bucket you also need to configure this CORS policy (under the Permissions tab) for the Log Insights functionality:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-<CORSRule>
-    <AllowedOrigin>*</AllowedOrigin>
-    <AllowedMethod>GET</AllowedMethod>
-    <ExposeHeader>x-amz-meta-x-amz-iv</ExposeHeader>
-    <ExposeHeader>x-amz-meta-x-amz-unencrypted-content-length</ExposeHeader>
-    <ExposeHeader>x-amz-meta-x-amz-wrap-alg</ExposeHeader>
-    <ExposeHeader>x-amz-meta-x-amz-cek-alg</ExposeHeader>
-    <ExposeHeader>x-amz-meta-x-amz-key-v2</ExposeHeader>
-    <ExposeHeader>x-amz-meta-x-amz-matdesc</ExposeHeader>
-    <AllowedHeader>Authorization</AllowedHeader>
-    <AllowedHeader>Range</AllowedHeader>
-</CORSRule>
-</CORSConfiguration>
-```
-
-## 4. Configuration on pganalyze Docker container
+## 3. Configuration on pganalyze Docker container
 
 You will need to add the following configuration to the Docker container:
 

--- a/install/amazon_rds/03_setup_iam_policy.mdx
+++ b/install/amazon_rds/03_setup_iam_policy.mdx
@@ -15,7 +15,7 @@ We now need to set up an IAM policy and user that the collector can use to acces
 
 To start, go to **[Create IAM policy](https://console.aws.amazon.com/iam/home#/policies$new?step=edit)**, select JSON and then paste the following policy:
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [


### PR DESCRIPTION
```
Enterprise EKS guide: Use identical IAM policy to regular RDS setup

This was using an outdated version of the policy that did not grant
access to rds:DescribeDBClusters, which is needed for the auto-discovery
of Aurora instances.

In passing, add json syntax highlighting to the regular RDS setup guide.
```

```
Enterprise Server: Remove CORS policy requirement for S3 bucket

Since we now always fetch the logs via the regular pganalyze webserver
for Enterprise Server (to make setup easier), we no longer require the
use of this CORS policy to allow the client-side to access S3 directly.
```