### PR TITLE
Enterprise 2023.03.0 release: Add missing note re: required migration

### DIFF
--- a/enterprise/releases/2023-03-0.mdx
+++ b/enterprise/releases/2023-03-0.mdx
@@ -8,6 +8,7 @@ backlink_title: 'pganalyze Enterprise Server: Release Changelog'
 
 ## Notes
 
+- This release requires a database migration when coming from older releases, be sure to follow the [recommended upgrade steps](/docs/enterprise/upgrade)
 - New minimum Postgres version for monitored servers: **Postgres 10 or newer**
 - New minimum required pganalyze collector version: [0.38.0](https://github.com/pganalyze/collector/blob/main/CHANGELOG.md#0380------2021-03-31) or newer
   - You may need to upgrade the collector if you run it outside the Enterprise Server container


### PR DESCRIPTION
We've had this as a standard note on each release that requires database migrations to be run, so continue the practice.