### PR TITLE
Show SignupCTA public only (not in-app) for Azure configuration

### DIFF
--- a/install/azure_database/01_configure_azure_instance.mdx
+++ b/install/azure_database/01_configure_azure_instance.mdx
@@ -49,6 +49,8 @@ Continue by creating the monitoring user:
 <Link className="btn btn-success" to="02_create_monitoring_user">
   Proceed to Step 2: Create Monitoring User
 </Link>
-<br />
-<br />
-<div><SignupCTA event-label="Docs"></SignupCTA></div>
+<PublicOnly>
+  <br />
+  <br />
+  <div><SignupCTA event-label="Docs"></SignupCTA></div>
+</PublicOnly>


### PR DESCRIPTION
This doc will be used in-app too, so it's important not to show SignupCTA in app (otherwise it errors, also the signup CTA doesn't make sense to have in-app).