### PR TITLE
Azure setup: Remove outdated @your_db username example

### DIFF
--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -396,7 +396,7 @@ Only relevant if you are running your database in Azure using Azure Database for
     <tr>
       <td>azure_ad_client_id (<code>AZURE_AD_CLIENT_ID</code>)</td>
       <td>[none]</td>
-      <td>The "Application (client) ID" on your application</td>
+      <td>The "Application (client) ID" on your application. Alternatively, when using a Managed Identity, this can also be used to define which identity to use, when a VM has multiple identities assigned.</td>
     </tr>
     <tr>
       <td>azure_ad_client_secret (<code>AZURE_AD_CLIENT_SECRET</code>)</td>

--- a/install/azure_database/04_configure_the_collector_docker.mdx
+++ b/install/azure_database/04_configure_the_collector_docker.mdx
@@ -27,7 +27,7 @@ export const CollectorDotEnv = ({ apiKey }) => {
       {`PGA_API_KEY=${apiKey || "your-organization-api-key"}
 DB_HOST=your_db.postgres.database.azure.com
 DB_NAME=your_database_name
-DB_USERNAME=your_monitoring_user@your_db
+DB_USERNAME=your_monitoring_user
 DB_PASSWORD=your_monitoring_user_password
 AZURE_DB_SERVER_NAME=your_db`}
     </CodeBlock>

--- a/install/azure_database/04_configure_the_collector_package.mdx
+++ b/install/azure_database/04_configure_the_collector_package.mdx
@@ -29,7 +29,7 @@ api_key = ${apiKey ?? 'your_pga_organization_api_key'}\n
 [server1]
 db_host = your_db.postgres.database.azure.com
 db_name = your_database_name
-db_username = your_monitoring_user@your_db
+db_username = your_monitoring_user
 db_password = your_monitoring_user_password
 azure_db_server_name = your_db`}
     </CodeBlock>

--- a/log-insights/setup/azure-database/troubleshooting.mdx
+++ b/log-insights/setup/azure-database/troubleshooting.mdx
@@ -14,22 +14,27 @@ server has not been able to deliver a message yet to the Event Hub. There is a d
 We recommend waiting 5 minutes, and then retrying. You can verify whether the Event Hub
 has received any messages by navigating to it in the Azure Portal.
 
-If this error persists, verify that you've configured the diagnostic setting in Step 3 correctly.
+If this error persists, verify that you've configured [the diagnostic setting in Step 3](/docs/log-insights/setup/azure-database/03_stream_logs_into_event_hub) correctly.
 
 ### Error: "status code 401 and description: Attempted to perform an unauthorized operation."
 
 This occurs when the collector can't access the Azure Event Hub API.
 
-Review whether you have followed Step 1 correctly for Managed Identity, or have setup
-the Azure AD application as documented below.
+Review whether [you have followed Step 2](/docs/log-insights/setup/azure-database/02_set_up_azure_event_hub) fully and assigned the "Azure Event Hubs Data Receiver" permission for the Managed Identity (or Azure AD application) to your Azure Event Hub.
 
 ### Error: "failed to configure Azure AD JWT provider"
 
-This error occurs when there is no authentication configured - when using Managed Identity,
-verify that you have actually assigned the identity to your VM.
+This error occurs when there is no authentication configured.
+
+When using Managed Identity, verify that you have actually assigned the identity to your VM.
+[Read more in the Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vm#assign-a-user-assigned-managed-identity-to-an-existing-vm).
+
+This may also occur when you have multiple user-assigned managed identities set for your virtual machine.
+Try removing any unrelated managed identities, or explicitly set the `azure_ad_client_id` / `AZURE_AD_CLIENT_ID` setting to
+the Managed Identity's Client ID.
 
 ### Error: "failed to connect to the Event Hub management node"
 
-Double check your Event Hub namespace and Event Hub name that you have configured in Step 4.
+Double check your Event Hub namespace and Event Hub name that [you have configured in Step 5](/docs/log-insights/setup/azure-database/05_configure_collector).
 
 


### PR DESCRIPTION
This was needed for Single Server, but by now that has been deprecated for a while, and the newer Flexible Server no longer requires this.

---

In passing, also add an extra docs link for Log Insights setup troubleshooting on Azure.