### PR TITLE
Fix docs typo

### DIFF
--- a/components/CheckDocumentation/vacuum/InefficientIndexPhase.tsx
+++ b/components/CheckDocumentation/vacuum/InefficientIndexPhase.tsx
@@ -23,7 +23,7 @@ const InefficientIndexPhaseTrigger: React.FunctionComponent<CheckTriggerProps> =
         {" "}in the last 24h have had multiple index scan phases.
       </p>
       <p>
-        Ignores situations where configured autovacuum mmemory is already set to the
+        Ignores situations where configured autovacuum memory is already set to the
         maximum possible value of <code>1GB</code>.
       </p>
     </>


### PR DESCRIPTION
This was pointed out in the review for #149, but an unrelated fix
resolved the conversation and I missed it.
