### PR TITLE
Add VACUUM: Bloat - VACUUM Blocked By Xmin Horizon check

### DIFF
--- a/components/CheckDocumentation/index.tsx
+++ b/components/CheckDocumentation/index.tsx
@@ -19,7 +19,7 @@ import HighLag from "./replication/HighLag";
 import FollowerMissing from "./replication/FollowerMissing";
 import VacuumInefficientIndexPhase from "./vacuum/InefficientIndexPhase";
 import InsufficientVacuumFrequency from "./vacuum/InsufficientVacuumFrequency";
-import XminHorizonBehind from "./vacuum/XminHorizonBehind";
+import XminHorizon from "./vacuum/XminHorizon";
 
 const Docs: {
   [category: string]: { [check: string]: CheckDocs };
@@ -56,7 +56,7 @@ const Docs: {
   vacuum: {
     inefficient_index_phase: VacuumInefficientIndexPhase,
     insufficient_vacuum_frequency: InsufficientVacuumFrequency,
-    xmin_horizon: XminHorizonBehind,
+    xmin_horizon: XminHorizon,
   },
 };
 

--- a/components/CheckDocumentation/index.tsx
+++ b/components/CheckDocumentation/index.tsx
@@ -19,6 +19,7 @@ import HighLag from "./replication/HighLag";
 import FollowerMissing from "./replication/FollowerMissing";
 import VacuumInefficientIndexPhase from "./vacuum/InefficientIndexPhase";
 import InsufficientVacuumFrequency from "./vacuum/InsufficientVacuumFrequency";
+import XminHorizonBehind from "./vacuum/XminHorizonBehind";
 
 const Docs: {
   [category: string]: { [check: string]: CheckDocs };
@@ -55,6 +56,7 @@ const Docs: {
   vacuum: {
     inefficient_index_phase: VacuumInefficientIndexPhase,
     insufficient_vacuum_frequency: InsufficientVacuumFrequency,
+    xmin_horizon: XminHorizonBehind,
   },
 };
 

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -63,38 +63,28 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
       </p>
       <h4>Common Causes and Solutions</h4>
       <ul>
-        <li>
-          <GuidanceByBackend
-            inApp={inApp}
-            xmin={byBackend && byBackend["xmin"]}
-          />
-        </li>
-        <li>
-          <GuidanceByReplicationSlot
-            inApp={inApp}
-            xmin={byReplicationSlot && byReplicationSlot["xmin"]}
-            serverReplicationUrl={serverReplicationUrl}
-          />
-        </li>
-        <li>
-          <GuidanceByReplicationSlotCatalog
-            inApp={inApp}
-            xmin={byReplicationSlotCatalog && byReplicationSlotCatalog["xmin"]}
-            serverReplicationUrl={serverReplicationUrl}
-          />
-        </li>
-        <li>
-          <GuidanceByStandby
-            inApp={inApp}
-            xmin={byStandby && byStandby["xmin"]}
-          />
-        </li>
-        <li>
-          <GuidanceByPreparedXact
-            inApp={inApp}
-            xmin={byPreparedXact && byPreparedXact["xmin"]}
-          />
-        </li>
+        <GuidanceByBackend
+          inApp={inApp}
+          xmin={byBackend && byBackend["xmin"]}
+        />
+        <GuidanceByReplicationSlot
+          inApp={inApp}
+          xmin={byReplicationSlot && byReplicationSlot["xmin"]}
+          serverReplicationUrl={serverReplicationUrl}
+        />
+        <GuidanceByReplicationSlotCatalog
+          inApp={inApp}
+          xmin={byReplicationSlotCatalog && byReplicationSlotCatalog["xmin"]}
+          serverReplicationUrl={serverReplicationUrl}
+        />
+        <GuidanceByStandby
+          inApp={inApp}
+          xmin={byStandby && byStandby["xmin"]}
+        />
+        <GuidanceByPreparedXact
+          inApp={inApp}
+          xmin={byPreparedXact && byPreparedXact["xmin"]}
+        />
       </ul>
     </div>
   );
@@ -110,7 +100,7 @@ const GuidanceByBackend: React.FunctionComponent<{
 
   const CodeBlock = useCodeBlock();
   return (
-    <>
+    <li>
       <h5>Long-running transactions</h5>
       <p>
         Long-running transactions may still need to access rows that could
@@ -142,7 +132,7 @@ const GuidanceByBackend: React.FunctionComponent<{
                 SELECT pg_terminate_backend('<query_pid>');`}
         />
       </CodeBlock>
-    </>
+    </li>
   );
 };
 
@@ -158,7 +148,7 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
   const Link = useSmartAnchor();
   const CodeBlock = useCodeBlock();
   return (
-    <>
+    <li>
       <h5>Lagging or stale physical replication slots</h5>
       <p>
         With physical streaming replication with{" "}
@@ -185,7 +175,7 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
       <CodeBlock>
         <SQL sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />
       </CodeBlock>
-    </>
+    </li>
   );
 };
 
@@ -201,7 +191,7 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
   const CodeBlock = useCodeBlock();
   const Link = useSmartAnchor();
   return (
-    <>
+    <li>
       <h5>Lagging or stale logical replication slots</h5>
       <p>
         With logical replication slots, replication can also get stale when DDL
@@ -232,7 +222,7 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
       <CodeBlock>
         <SQL sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />
       </CodeBlock>
-    </>
+    </li>
   );
 };
 
@@ -246,7 +236,7 @@ const GuidanceByStandby: React.FunctionComponent<{
 
   const CodeBlock = useCodeBlock();
   return (
-    <>
+    <li>
       <h5>Long-running queries on standbys</h5>
       <p>
         When <code>hot_standby_feedback</code> is on with physical streaming
@@ -284,7 +274,7 @@ const GuidanceByStandby: React.FunctionComponent<{
                   ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
         />
       </CodeBlock>
-    </>
+    </li>
   );
 };
 
@@ -298,7 +288,7 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
 
   const CodeBlock = useCodeBlock();
   return (
-    <>
+    <li>
       <h5>Abandoned prepared transactions</h5>
       <p>
         A transaction prepared for a two-phase commit will prevent cleanup until
@@ -331,7 +321,7 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
                 ROLLBACK PREPARED <gid_from_above>;`}
         />
       </CodeBlock>
-    </>
+    </li>
   );
 };
 

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -90,7 +90,12 @@ const GuidanceByBackend: React.FunctionComponent<{
     return null;
   }
 
-  const xminCode = <code>{xmin}</code>;
+  const xminBlock = xmin && (
+    <>
+      A long running transaction is holding back the xmin horizon at{" "}
+      <code>{xmin}</code>.
+    </>
+  );
   const CodeBlock = useCodeBlock();
   return (
     <>
@@ -101,8 +106,7 @@ const GuidanceByBackend: React.FunctionComponent<{
       </p>
       <h6>Solution</h6>
       <p>
-        {xmin &&
-          `A long running transaction is holding back the xmin horizon at ${xminCode}.`}
+        {xminBlock}
         You can find the transaction holding back the xmin horizon and its
         connection's pid by running the following command:
       </p>

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -47,6 +47,7 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
     byStandby = heldBackBy.find((v) => v["type"] === "standby");
     byPreparedXact = heldBackBy.find((v) => v["type"] === "prepared_xact");
   }
+  const inApp = heldBackBy === null;
   return (
     <div>
       <h4>Impact</h4>
@@ -61,33 +62,27 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
         the unnecessary table bloat or slow queries.
       </p>
       <h4>Common Causes and Solutions</h4>
-      <GuidanceByBackend
-        inApp={!heldBackBy}
-        xmin={byBackend && byBackend["xmin"]}
-      />
+      <GuidanceByBackend inApp={inApp} xmin={byBackend && byBackend["xmin"]} />
       <GuidanceByReplicationSlot
-        inApp={!heldBackBy}
+        inApp={inApp}
         xmin={byReplicationSlot && byReplicationSlot["xmin"]}
         serverReplicationUrl={serverReplicationUrl}
       />
       <GuidanceByReplicationSlotCatalog
-        inApp={!heldBackBy}
+        inApp={inApp}
         xmin={byReplicationSlotCatalog && byReplicationSlotCatalog["xmin"]}
         serverReplicationUrl={serverReplicationUrl}
       />
-      <GuidanceByStandby
-        inApp={!heldBackBy}
-        xmin={byStandby && byStandby["xmin"]}
-      />
+      <GuidanceByStandby inApp={inApp} xmin={byStandby && byStandby["xmin"]} />
       <GuidanceByPreparedXact
-        inApp={!heldBackBy}
+        inApp={inApp}
         xmin={byPreparedXact && byPreparedXact["xmin"]}
       />
     </div>
   );
 };
 
-const GuidanceByPreparedXact: React.FunctionComponent<{
+const GuidanceByBackend: React.FunctionComponent<{
   inApp: boolean;
   xmin: number;
 }> = ({ inApp, xmin }) => {
@@ -98,30 +93,110 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
   const CodeBlock = useCodeBlock();
   return (
     <>
-      <h5>Abandoned prepared transactions</h5>
+      <h5>Long-running transactions</h5>
       <p>
-        A transaction prepared for a two-phase commit will prevent cleanup until
-        it is either committed or rolled back.
+        Long-running transactions may still need to access rows that could
+        otherwise be considered dead, so they can block cleanup.
       </p>
       <h6>Solution</h6>
       <p>
-        {xmin ??
-          `A prepared transaction is holding back the xmin
-          horizon at
-                ${(<code>{xmin}</code>)}.`}
-        You can find the prepared transaction by running the following command:
+        {xmin &&
+          `A long running transaction is holding back the xmin horizon at ${(
+            <code>{xmin}</code>
+          )}.`}
+        You can find the transaction holding back the xmin horizon and its
+        connection's pid by running the following command:
       </p>
       <CodeBlock>
         <SQL
-          sql={`SELECT gid, prepared, owner, database, transaction AS xmin
-                  FROM pg_prepared_xacts
-                  ORDER BY age(transaction) DESC;`}
+          sql={`SELECT pid, datname, usename, state, backend_xmin, backend_xid
+                  FROM pg_stat_activity
+                  WHERE backend_xmin IS NOT NULL OR backend_xid IS NOT NULL
+                  ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
         />
       </CodeBlock>
       <p>
-        Once identified, you can either commit or cancel the transaction with{" "}
-        <SQL inline sql={`COMMIT PREPARED <gid_from_above>`} /> or
-        <SQL inline sql={`ROLLBACK PREPARED <gid_from_above>`} />.
+        You can cancel it with{" "}
+        <SQL inline sql={`SELECT pg_cancel_backend('<query_pid>');`} /> or{" "}
+        <SQL inline sql={`SELECT pg_terminate_backend('<query_pid>');`} />.
+      </p>
+    </>
+  );
+};
+
+const GuidanceByReplicationSlot: React.FunctionComponent<{
+  inApp: boolean;
+  xmin: number;
+  serverReplicationUrl: string;
+}> = ({ inApp, xmin, serverReplicationUrl }) => {
+  if (!inApp && xmin === null) {
+    return null;
+  }
+
+  const Link = useSmartAnchor();
+  return (
+    <>
+      <h5>Lagging or stale physical replication slots</h5>
+      <p>
+        With physical streaming replication with{" "}
+        <code>hot_standby_feedback</code> is on, when replication is lagging or
+        a replica server is stale (e.g. down, gone), the oldest transaction that
+        the replication slot needs the database to retain can be "stuck",
+        holding back the xmin horizon.
+      </p>
+      <h6>Solution</h6>
+      <p>
+        {xmin &&
+          `A replication slot is holding back the xmin horizon at ${(
+            <code>{xmin}</code>
+          )}.`}
+        You can check the replication status on the{" "}
+        <Link to={serverReplicationUrl}>Replication</Link> page.
+      </p>
+      <p>
+        If the replication slot is no longer used, remove it with{" "}
+        <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />.
+      </p>
+    </>
+  );
+};
+
+const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
+  inApp: boolean;
+  xmin: number;
+  serverReplicationUrl: string;
+}> = ({ inApp, xmin, serverReplicationUrl }) => {
+  if (!inApp && xmin === null) {
+    return null;
+  }
+
+  const Link = useSmartAnchor();
+  return (
+    <>
+      <h5>Lagging or stale logical replication slots</h5>
+      <p>
+        With logical replication slots, replication can also get stale when DDL
+        changes (database migrations) don't get applied to a replica server
+        (subscriber). When the subscriber was unable to replicate data due to a
+        schema mismatch, replication will error and get stale. This causes the
+        system catalogs xmin of the primary (publisher) to be held back until
+        replication resumes.
+      </p>
+      <h6>Solution</h6>
+      <p>
+        {xmin &&
+          `A replication slot is holding back the xmin horizon at ${(
+            <code>{xmin}</code>
+          )}, specifically with system catalogs.`}
+        You can check the replication status on the{" "}
+        <Link to={serverReplicationUrl}>Replication</Link> page. You may also
+        want to check logs on both the publisher and the subscriber for any
+        error messages regarding logical replication, such as schema
+        differences.
+      </p>
+      <p>
+        If the replication slot is no longer used, remove it with{" "}
+        <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />.
       </p>
     </>
   );
@@ -177,84 +252,7 @@ const GuidanceByStandby: React.FunctionComponent<{
   );
 };
 
-const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
-  inApp: boolean;
-  xmin: number;
-  serverReplicationUrl: string;
-}> = ({ inApp, xmin, serverReplicationUrl }) => {
-  if (!inApp && xmin === null) {
-    return null;
-  }
-
-  const Link = useSmartAnchor();
-  return (
-    <>
-      <h5>Lagging or stale logical replication slots</h5>
-      <p>
-        With logical replication slots, replication can also get stale when DDL
-        changes (database migrations) don't get applied to a replica server
-        (subscriber). When the subscriber was unable to replicate data due to a
-        schema mismatch, replication will error and get stale. This causes the
-        system catalogs xmin of the primary (publisher) to be held back until
-        replication resumes.
-      </p>
-      <h6>Solution</h6>
-      <p>
-        {xmin ??
-          `A replication slot is holding back the xmin horizon at
-                ${(<code>{xmin}</code>)}, specifically with
-                system catalogs.`}
-        You can check the replication status on the{" "}
-        <Link to={serverReplicationUrl}>Replication</Link> page. You may also
-        want to check logs on both the publisher and the subscriber for any
-        error messages regarding logical replication, such as schema
-        differences.
-      </p>
-      <p>
-        If the replication slot is no longer used, remove it with{" "}
-        <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />.
-      </p>
-    </>
-  );
-};
-
-const GuidanceByReplicationSlot: React.FunctionComponent<{
-  inApp: boolean;
-  xmin: number;
-  serverReplicationUrl: string;
-}> = ({ inApp, xmin, serverReplicationUrl }) => {
-  if (!inApp && xmin === null) {
-    return null;
-  }
-
-  const Link = useSmartAnchor();
-  return (
-    <>
-      <h5>Lagging or stale physical replication slots</h5>
-      <p>
-        With physical streaming replication with{" "}
-        <code>hot_standby_feedback</code> is on, when replication is lagging or
-        a replica server is stale (e.g. down, gone), the oldest transaction that
-        the replication slot needs the database to retain can be "stuck",
-        holding back the xmin horizon.
-      </p>
-      <h6>Solution</h6>
-      <p>
-        {xmin ??
-          `A replication slot is holding back the xmin horizon at
-                ${(<code>{xmin}</code>)}.`}
-        You can check the replication status on the{" "}
-        <Link to={serverReplicationUrl}>Replication</Link> page.
-      </p>
-      <p>
-        If the replication slot is no longer used, remove it with{" "}
-        <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />.
-      </p>
-    </>
-  );
-};
-
-const GuidanceByBackend: React.FunctionComponent<{
+const GuidanceByPreparedXact: React.FunctionComponent<{
   inApp: boolean;
   xmin: number;
 }> = ({ inApp, xmin }) => {
@@ -265,31 +263,30 @@ const GuidanceByBackend: React.FunctionComponent<{
   const CodeBlock = useCodeBlock();
   return (
     <>
-      <h5>Long-running transactions</h5>
+      <h5>Abandoned prepared transactions</h5>
       <p>
-        Long-running transactions may still need to access rows that could
-        otherwise be considered dead, so they can block cleanup.
+        A transaction prepared for a two-phase commit will prevent cleanup until
+        it is either committed or rolled back.
       </p>
       <h6>Solution</h6>
       <p>
-        {xmin ??
-          `A long running transaction is holding back the xmin horizon at
-                ${(<code>{xmin}</code>)}.`}
-        You can find the transaction holding back the xmin horizon and its
-        connection's pid by running the following command:
+        {xmin &&
+          `A prepared transaction is holding back the xmin horizon at ${(
+            <code>{xmin}</code>
+          )}.`}
+        You can find the prepared transaction by running the following command:
       </p>
       <CodeBlock>
         <SQL
-          sql={`SELECT pid, datname, usename, state, backend_xmin, backend_xid
-                  FROM pg_stat_activity
-                  WHERE backend_xmin IS NOT NULL OR backend_xid IS NOT NULL
-                  ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
+          sql={`SELECT gid, prepared, owner, database, transaction AS xmin
+                  FROM pg_prepared_xacts
+                  ORDER BY age(transaction) DESC;`}
         />
       </CodeBlock>
       <p>
-        You can cancel it with{" "}
-        <SQL inline sql={`SELECT pg_cancel_backend('<query_pid>');`} /> or{" "}
-        <SQL inline sql={`SELECT pg_terminate_backend('<query_pid>');`} />.
+        Once identified, you can either commit or cancel the transaction with{" "}
+        <SQL inline sql={`COMMIT PREPARED <gid_from_above>`} /> or
+        <SQL inline sql={`ROLLBACK PREPARED <gid_from_above>`} />.
       </p>
     </>
   );

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -102,13 +102,9 @@ const GuidanceByBackend: React.FunctionComponent<{
         Long-running transactions may still need to access rows that could
         otherwise be considered dead, so they can block cleanup.
       </p>
-      <p>
-        This is the most common cause of the xmin horizon being held back.
-        However, it's also possible to observe this due to other causes. In such
-        cases, it's recommended to investigate the alternative causes first, as
-        they are more likely to be the root cause.
-      </p>
-      <h6>Solution</h6>
+      <h6>
+        <b>Solution</b>
+      </h6>
       {heldBackInfo && (
         <p>
           A long running transaction is holding back the xmin horizon at{" "}
@@ -159,7 +155,9 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
         the replication slot needs the database to retain can be "stuck",
         holding back the xmin horizon.
       </p>
-      <h6>Solution</h6>
+      <h6>
+        <b>Solution</b>
+      </h6>
       {heldBackInfo && (
         <p>
           A replication slot is holding back the xmin horizon at{" "}
@@ -203,7 +201,9 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
         system catalogs xmin of the primary (publisher) to be held back until
         replication resumes.
       </p>
-      <h6>Solution</h6>
+      <h6>
+        <b>Solution</b>
+      </h6>
       {heldBackInfo && (
         <p>
           A replication slot is holding back the xmin horizon at{" "}
@@ -246,7 +246,9 @@ const GuidanceByStandby: React.FunctionComponent<{
         replication, queries on standbys will hold back the xmin horizon just as
         if they were running on the primary.
       </p>
-      <h6>Solution</h6>
+      <h6>
+        <b>Solution</b>
+      </h6>
       {heldBackInfo && (
         <p>
           A long running query on a standby is holding back the xmin horizon at{" "}
@@ -297,7 +299,9 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
         A transaction prepared for a two-phase commit will prevent cleanup until
         it is either committed or rolled back.
       </p>
-      <h6>Solution</h6>
+      <h6>
+        <b>Solution</b>
+      </h6>
       {heldBackInfo && (
         <p>
           A prepared transaction is holding back the xmin horizon at{" "}

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -64,7 +64,7 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
       </p>
       <p>
         When VACUUM is blocked and dead rows can't be cleaned, it can result to
-        the unnecessary table bloat or slow queries.
+        table bloat and slow queries.
       </p>
       <h4>{causeTitle}</h4>
       <ul>
@@ -101,6 +101,12 @@ const GuidanceByBackend: React.FunctionComponent<{
       <p>
         Long-running transactions may still need to access rows that could
         otherwise be considered dead, so they can block cleanup.
+      </p>
+      <p>
+        This is the most common cause of the xmin horizon being held back.
+        However, it's also possible to observe this due to other causes. In such
+        cases, it's recommended to investigate the alternative causes first, as
+        they are more likely to be the root cause.
       </p>
       <h6>Solution</h6>
       {heldBackInfo && (

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -104,7 +104,7 @@ const GuidanceByBackend: React.FunctionComponent<{
   inApp: boolean;
   xmin: number | null;
 }> = ({ inApp, xmin }) => {
-  if (inApp && xmin === null) {
+  if (inApp && !xmin) {
     return null;
   }
 
@@ -151,7 +151,7 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
   xmin: number | null;
   serverReplicationUrl: string;
 }> = ({ inApp, xmin, serverReplicationUrl }) => {
-  if (inApp && xmin === null) {
+  if (inApp && !xmin) {
     return null;
   }
 
@@ -194,7 +194,7 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
   xmin: number | null;
   serverReplicationUrl: string;
 }> = ({ inApp, xmin, serverReplicationUrl }) => {
-  if (inApp && xmin === null) {
+  if (inApp && !xmin) {
     return null;
   }
 
@@ -240,7 +240,7 @@ const GuidanceByStandby: React.FunctionComponent<{
   inApp: boolean;
   xmin: number | null;
 }> = ({ inApp, xmin }) => {
-  if (inApp && xmin === null) {
+  if (inApp && !xmin) {
     return null;
   }
 
@@ -292,7 +292,7 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
   inApp: boolean;
   xmin: number | null;
 }> = ({ inApp, xmin }) => {
-  if (inApp && xmin === null) {
+  if (inApp && !xmin) {
     return null;
   }
 

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -62,22 +62,40 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
         the unnecessary table bloat or slow queries.
       </p>
       <h4>Common Causes and Solutions</h4>
-      <GuidanceByBackend inApp={inApp} xmin={byBackend && byBackend["xmin"]} />
-      <GuidanceByReplicationSlot
-        inApp={inApp}
-        xmin={byReplicationSlot && byReplicationSlot["xmin"]}
-        serverReplicationUrl={serverReplicationUrl}
-      />
-      <GuidanceByReplicationSlotCatalog
-        inApp={inApp}
-        xmin={byReplicationSlotCatalog && byReplicationSlotCatalog["xmin"]}
-        serverReplicationUrl={serverReplicationUrl}
-      />
-      <GuidanceByStandby inApp={inApp} xmin={byStandby && byStandby["xmin"]} />
-      <GuidanceByPreparedXact
-        inApp={inApp}
-        xmin={byPreparedXact && byPreparedXact["xmin"]}
-      />
+      <ul>
+        <li>
+          <GuidanceByBackend
+            inApp={inApp}
+            xmin={byBackend && byBackend["xmin"]}
+          />
+        </li>
+        <li>
+          <GuidanceByReplicationSlot
+            inApp={inApp}
+            xmin={byReplicationSlot && byReplicationSlot["xmin"]}
+            serverReplicationUrl={serverReplicationUrl}
+          />
+        </li>
+        <li>
+          <GuidanceByReplicationSlotCatalog
+            inApp={inApp}
+            xmin={byReplicationSlotCatalog && byReplicationSlotCatalog["xmin"]}
+            serverReplicationUrl={serverReplicationUrl}
+          />
+        </li>
+        <li>
+          <GuidanceByStandby
+            inApp={inApp}
+            xmin={byStandby && byStandby["xmin"]}
+          />
+        </li>
+        <li>
+          <GuidanceByPreparedXact
+            inApp={inApp}
+            xmin={byPreparedXact && byPreparedXact["xmin"]}
+          />
+        </li>
+      </ul>
     </div>
   );
 };
@@ -180,7 +198,7 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
     return null;
   }
 
-  const xminCode = <code>{xmin}</code>;
+  const CodeBlock = useCodeBlock();
   const Link = useSmartAnchor();
   return (
     <>
@@ -194,9 +212,13 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
         replication resumes.
       </p>
       <h6>Solution</h6>
+      {xmin && (
+        <p>
+          A replication slot is holding back the xmin horizon at{" "}
+          <code>{xmin}</code>, specifically with system catalogs.
+        </p>
+      )}
       <p>
-        {xmin &&
-          `A replication slot is holding back the xmin horizon at ${xminCode}, specifically with system catalogs.`}
         You can check the replication status on the{" "}
         <Link to={serverReplicationUrl}>Replication</Link> page. You may also
         want to check logs on both the publisher and the subscriber for any
@@ -204,9 +226,12 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
         differences.
       </p>
       <p>
-        If the replication slot is no longer used, remove it with{" "}
-        <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />.
+        If the replication slot is no longer used, remove it it by running the
+        following command:
       </p>
+      <CodeBlock>
+        <SQL sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />
+      </CodeBlock>
     </>
   );
 };
@@ -219,7 +244,6 @@ const GuidanceByStandby: React.FunctionComponent<{
     return null;
   }
 
-  const xminCode = <code>{xmin}</code>;
   const CodeBlock = useCodeBlock();
   return (
     <>
@@ -230,11 +254,13 @@ const GuidanceByStandby: React.FunctionComponent<{
         if they were running on the primary.
       </p>
       <h6>Solution</h6>
+      {xmin && (
+        <p>
+          A long running query on a standby is holding back the xmin horizon at{" "}
+          <code>{xmin}</code>.
+        </p>
+      )}
       <p>
-        {xmin &&
-          `A long running query on a standby is holding back the xmin
-          horizon at
-                ${xminCode}.`}
         You can find the <code>xmin</code> of all standby servers by running the
         following command:
       </p>
@@ -270,7 +296,6 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
     return null;
   }
 
-  const xminCode = <code>{xmin}</code>;
   const CodeBlock = useCodeBlock();
   return (
     <>
@@ -280,9 +305,13 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
         it is either committed or rolled back.
       </p>
       <h6>Solution</h6>
+      {xmin && (
+        <p>
+          A prepared transaction is holding back the xmin horizon at{" "}
+          <code>{xmin}</code>.
+        </p>
+      )}
       <p>
-        {xmin &&
-          `A prepared transaction is holding back the xmin horizon at ${xminCode}.`}
         You can find the prepared transaction by running the following command:
       </p>
       <CodeBlock>
@@ -293,10 +322,15 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
         />
       </CodeBlock>
       <p>
-        Once identified, you can either commit or cancel the transaction with{" "}
-        <SQL inline sql={`COMMIT PREPARED <gid_from_above>`} /> or{" "}
-        <SQL inline sql={`ROLLBACK PREPARED <gid_from_above>`} />.
+        Once identified, you can either commit or cancel the transaction by
+        running either of commands:
       </p>
+      <CodeBlock>
+        <SQL
+          sql={`COMMIT PREPARED <gid_from_above>;
+                ROLLBACK PREPARED <gid_from_above>;`}
+        />
+      </CodeBlock>
     </>
   );
 };

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -47,7 +47,7 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
     byStandby = heldBackBy.find((v) => v["type"] === "standby");
     byPreparedXact = heldBackBy.find((v) => v["type"] === "prepared_xact");
   }
-  const inApp = heldBackBy === null;
+  const inApp = issue !== null;
   return (
     <div>
       <h4>Impact</h4>
@@ -86,7 +86,7 @@ const GuidanceByBackend: React.FunctionComponent<{
   inApp: boolean;
   xmin: number | null;
 }> = ({ inApp, xmin }) => {
-  if (!inApp && xmin === null) {
+  if (inApp && xmin === null) {
     return null;
   }
 
@@ -128,7 +128,7 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
   xmin: number | null;
   serverReplicationUrl: string;
 }> = ({ inApp, xmin, serverReplicationUrl }) => {
-  if (!inApp && xmin === null) {
+  if (inApp && xmin === null) {
     return null;
   }
 
@@ -164,7 +164,7 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
   xmin: number | null;
   serverReplicationUrl: string;
 }> = ({ inApp, xmin, serverReplicationUrl }) => {
-  if (!inApp && xmin === null) {
+  if (inApp && xmin === null) {
     return null;
   }
 
@@ -203,7 +203,7 @@ const GuidanceByStandby: React.FunctionComponent<{
   inApp: boolean;
   xmin: number | null;
 }> = ({ inApp, xmin }) => {
-  if (!inApp && xmin === null) {
+  if (inApp && xmin === null) {
     return null;
   }
 
@@ -254,7 +254,7 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
   inApp: boolean;
   xmin: number | null;
 }> = ({ inApp, xmin }) => {
-  if (!inApp && xmin === null) {
+  if (inApp && xmin === null) {
     return null;
   }
 

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -47,7 +47,7 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
     byStandby = heldBackBy.find((v) => v["type"] === "standby");
     byPreparedXact = heldBackBy.find((v) => v["type"] === "prepared_xact");
   }
-  const inApp = issue !== null;
+  const inApp = issue != null;
   return (
     <div>
       <h4>Impact</h4>
@@ -90,12 +90,6 @@ const GuidanceByBackend: React.FunctionComponent<{
     return null;
   }
 
-  const xminBlock = xmin && (
-    <>
-      A long running transaction is holding back the xmin horizon at{" "}
-      <code>{xmin}</code>.
-    </>
-  );
   const CodeBlock = useCodeBlock();
   return (
     <>
@@ -105,8 +99,13 @@ const GuidanceByBackend: React.FunctionComponent<{
         otherwise be considered dead, so they can block cleanup.
       </p>
       <h6>Solution</h6>
+      {xmin && (
+        <p>
+          A long running transaction is holding back the xmin horizon at{" "}
+          <code>{xmin}</code>.
+        </p>
+      )}
       <p>
-        {xminBlock}
         You can find the transaction holding back the xmin horizon and its
         connection's pid by running the following command:
       </p>
@@ -118,11 +117,13 @@ const GuidanceByBackend: React.FunctionComponent<{
                   ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
         />
       </CodeBlock>
-      <p>
-        You can cancel it with{" "}
-        <SQL inline sql={`SELECT pg_cancel_backend('<query_pid>');`} /> or{" "}
-        <SQL inline sql={`SELECT pg_terminate_backend('<query_pid>');`} />.
-      </p>
+      <p>You can cancel it by running either of commands:</p>
+      <CodeBlock>
+        <SQL
+          sql={`SELECT pg_cancel_backend('<query_pid>');
+                SELECT pg_terminate_backend('<query_pid>');`}
+        />
+      </CodeBlock>
     </>
   );
 };
@@ -136,8 +137,8 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
     return null;
   }
 
-  const xminCode = <code>{xmin}</code>;
   const Link = useSmartAnchor();
+  const CodeBlock = useCodeBlock();
   return (
     <>
       <h5>Lagging or stale physical replication slots</h5>
@@ -149,16 +150,23 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
         holding back the xmin horizon.
       </p>
       <h6>Solution</h6>
+      {xmin && (
+        <p>
+          A replication slot is holding back the xmin horizon at{" "}
+          <code>{xmin}</code>.
+        </p>
+      )}
       <p>
-        {xmin &&
-          `A replication slot is holding back the xmin horizon at ${xminCode}.`}
         You can check the replication status on the{" "}
         <Link to={serverReplicationUrl}>Replication</Link> page.
       </p>
       <p>
-        If the replication slot is no longer used, remove it with{" "}
-        <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />.
+        If the replication slot is no longer used, you can remove it by running
+        the following command:
       </p>
+      <CodeBlock>
+        <SQL sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />
+      </CodeBlock>
     </>
   );
 };

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../util/checks";
 import { useCodeBlock } from "../../CodeBlock";
 
-const XminHorizonBehindTrigger: React.FunctionComponent<CheckTriggerProps> = ({
+const XminHorizonTrigger: React.FunctionComponent<CheckTriggerProps> = ({
   config,
 }) => {
   const threshold = config.settings["behind_days"] as number;
@@ -22,7 +22,7 @@ const XminHorizonBehindTrigger: React.FunctionComponent<CheckTriggerProps> = ({
   );
 };
 
-const XminHorizonBehindGuidance: React.FunctionComponent<
+const XminHorizonGuidance: React.FunctionComponent<
   CheckGuidanceProps
 > = ({ issue }) => {
   const CodeBlock = useCodeBlock();
@@ -162,8 +162,8 @@ const XminHorizonBehindGuidance: React.FunctionComponent<
 const documentation: CheckDocs = {
   description:
     "Monitors the xmin horizon of the server and creates an info issue if the xmin horizon is not making any progress.",
-  Trigger: XminHorizonBehindTrigger,
-  Guidance: XminHorizonBehindGuidance,
+  Trigger: XminHorizonTrigger,
+  Guidance: XminHorizonGuidance,
 };
 
 export default documentation;

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -37,15 +37,15 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
   let byStandby = null;
   let byPreparedXact = null;
   if (heldBackBy) {
-    byBackend = heldBackBy.find((v) => v["type"] === "backend");
+    byBackend = heldBackBy.find((v: any) => v["type"] === "backend");
     byReplicationSlot = heldBackBy.find(
-      (v) => v["type"] === "replication_slot"
+      (v: any) => v["type"] === "replication_slot"
     );
     byReplicationSlotCatalog = heldBackBy.find(
-      (v) => v["type"] === "replication_slot_catalog"
+      (v: any) => v["type"] === "replication_slot_catalog"
     );
-    byStandby = heldBackBy.find((v) => v["type"] === "standby");
-    byPreparedXact = heldBackBy.find((v) => v["type"] === "prepared_xact");
+    byStandby = heldBackBy.find((v: any) => v["type"] === "standby");
+    byPreparedXact = heldBackBy.find((v: any) => v["type"] === "prepared_xact");
   }
   const inApp = issue != null;
   const causeTitle = inApp

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -16,11 +16,11 @@ const XminHorizonTrigger: React.FunctionComponent<CheckTriggerProps> = ({
   const hourPluralized = threshold === 1 ? "hour" : "hours";
   return (
     <p>
-      Detects when the xmin horizon on the server was assigned at more than{" "}
+      Detects when the xmin horizon on the server was assigned more than{" "}
       <code>{threshold}</code> {hourPluralized} ago and creates an issue with
       severity "info". The issue will be created even if no VACUUM is currently
       blocked by this, as this will potentially block any future VACUUMs.
-      Resolves once the xmin horizon is no longer behind.
+      Resolves once the age of the xmin horizon is no longer behind.
     </p>
   );
 };
@@ -63,7 +63,7 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
         will be blocked and will not be able to clean up dead rows.
       </p>
       <p>
-        When VACUUM is blocked and dead rows can't be cleaned, it can result to
+        When VACUUM is blocked and dead rows can't be cleaned, it can result in
         table bloat and slow queries.
       </p>
       <h4>{causeTitle}</h4>
@@ -125,10 +125,7 @@ const GuidanceByBackend: React.FunctionComponent<{
       </CodeBlock>
       <p>You can cancel it by running either of commands:</p>
       <CodeBlock>
-        <SQL
-          sql={`SELECT pg_cancel_backend('<query_pid>');
-                SELECT pg_terminate_backend('<query_pid>');`}
-        />
+        <SQL sql={`SELECT pg_cancel_backend('<query_pid>');`} />
       </CodeBlock>
     </li>
   );
@@ -151,9 +148,9 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
       <p>
         With physical streaming replication with{" "}
         <code>hot_standby_feedback</code> is on, when replication is lagging or
-        a replica server is stale (e.g. down, gone), the oldest transaction that
-        the replication slot needs the database to retain can be "stuck",
-        holding back the xmin horizon.
+        a replica server is stale (e.g. down), the oldest transaction that the
+        replication slot needs the database to retain can be "stuck", holding
+        back the xmin horizon.
       </p>
       <h6>
         <b>Solution</b>
@@ -198,8 +195,8 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
         changes (database migrations) don't get applied to a replica server
         (subscriber). When the subscriber was unable to replicate data due to a
         schema mismatch, replication will error and get stale. This causes the
-        system catalogs xmin of the primary (publisher) to be held back until
-        replication resumes.
+        xmin of the system catalogs of the primary (publisher) to be held back
+        until replication resumes.
       </p>
       <h6>
         <b>Solution</b>
@@ -296,8 +293,13 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
     <li>
       <h5>Abandoned prepared transactions</h5>
       <p>
-        A transaction prepared for a two-phase commit will prevent cleanup until
-        it is either committed or rolled back.
+        <a
+          href="https://www.postgresql.org/docs/current/sql-prepare-transaction.html"
+          target="_blank"
+        >
+          A transaction prepared for a two-phase commit
+        </a>{" "}
+        will prevent cleanup until it is either committed or rolled back.
       </p>
       <h6>
         <b>Solution</b>

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -48,6 +48,11 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
     byPreparedXact = heldBackBy.find((v) => v["type"] === "prepared_xact");
   }
   const inApp = issue != null;
+  const causeTitle = inApp
+    ? heldBackBy.length > 1
+      ? "Identified Causes and Solutions"
+      : "Identified Cause and Solution"
+    : "Common Causes and Solutions";
   return (
     <div>
       <h4>Impact</h4>
@@ -61,30 +66,21 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
         When VACUUM is blocked and dead rows can't be cleaned, it can result to
         the unnecessary table bloat or slow queries.
       </p>
-      <h4>Common Causes and Solutions</h4>
+      <h4>{causeTitle}</h4>
       <ul>
-        <GuidanceByBackend
-          inApp={inApp}
-          xmin={byBackend && byBackend["xmin"]}
-        />
+        <GuidanceByBackend inApp={inApp} heldBackInfo={byBackend} />
         <GuidanceByReplicationSlot
           inApp={inApp}
-          xmin={byReplicationSlot && byReplicationSlot["xmin"]}
+          heldBackInfo={byReplicationSlot}
           serverReplicationUrl={serverReplicationUrl}
         />
         <GuidanceByReplicationSlotCatalog
           inApp={inApp}
-          xmin={byReplicationSlotCatalog && byReplicationSlotCatalog["xmin"]}
+          heldBackInfo={byReplicationSlotCatalog}
           serverReplicationUrl={serverReplicationUrl}
         />
-        <GuidanceByStandby
-          inApp={inApp}
-          xmin={byStandby && byStandby["xmin"]}
-        />
-        <GuidanceByPreparedXact
-          inApp={inApp}
-          xmin={byPreparedXact && byPreparedXact["xmin"]}
-        />
+        <GuidanceByStandby inApp={inApp} heldBackInfo={byStandby} />
+        <GuidanceByPreparedXact inApp={inApp} heldBackInfo={byPreparedXact} />
       </ul>
     </div>
   );
@@ -92,9 +88,9 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
 
 const GuidanceByBackend: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number | null;
-}> = ({ inApp, xmin }) => {
-  if (inApp && !xmin) {
+  heldBackInfo: number | null;
+}> = ({ inApp, heldBackInfo }) => {
+  if (inApp && !heldBackInfo) {
     return null;
   }
 
@@ -107,10 +103,10 @@ const GuidanceByBackend: React.FunctionComponent<{
         otherwise be considered dead, so they can block cleanup.
       </p>
       <h6>Solution</h6>
-      {xmin && (
+      {heldBackInfo && (
         <p>
           A long running transaction is holding back the xmin horizon at{" "}
-          <code>{xmin}</code>.
+          <code>{heldBackInfo["xmin"]}</code>.
         </p>
       )}
       <p>
@@ -138,10 +134,10 @@ const GuidanceByBackend: React.FunctionComponent<{
 
 const GuidanceByReplicationSlot: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number | null;
+  heldBackInfo: number | null;
   serverReplicationUrl: string;
-}> = ({ inApp, xmin, serverReplicationUrl }) => {
-  if (inApp && !xmin) {
+}> = ({ inApp, heldBackInfo, serverReplicationUrl }) => {
+  if (inApp && !heldBackInfo) {
     return null;
   }
 
@@ -158,10 +154,10 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
         holding back the xmin horizon.
       </p>
       <h6>Solution</h6>
-      {xmin && (
+      {heldBackInfo && (
         <p>
           A replication slot is holding back the xmin horizon at{" "}
-          <code>{xmin}</code>.
+          <code>{heldBackInfo["xmin"]}</code>.
         </p>
       )}
       <p>
@@ -181,10 +177,10 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
 
 const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number | null;
+  heldBackInfo: number | null;
   serverReplicationUrl: string;
-}> = ({ inApp, xmin, serverReplicationUrl }) => {
-  if (inApp && !xmin) {
+}> = ({ inApp, heldBackInfo, serverReplicationUrl }) => {
+  if (inApp && !heldBackInfo) {
     return null;
   }
 
@@ -202,10 +198,11 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
         replication resumes.
       </p>
       <h6>Solution</h6>
-      {xmin && (
+      {heldBackInfo && (
         <p>
           A replication slot is holding back the xmin horizon at{" "}
-          <code>{xmin}</code>, specifically with system catalogs.
+          <code>{heldBackInfo["xmin"]}</code>, specifically with system
+          catalogs.
         </p>
       )}
       <p>
@@ -228,9 +225,9 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
 
 const GuidanceByStandby: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number | null;
-}> = ({ inApp, xmin }) => {
-  if (inApp && !xmin) {
+  heldBackInfo: number | null;
+}> = ({ inApp, heldBackInfo }) => {
+  if (inApp && !heldBackInfo) {
     return null;
   }
 
@@ -244,10 +241,10 @@ const GuidanceByStandby: React.FunctionComponent<{
         if they were running on the primary.
       </p>
       <h6>Solution</h6>
-      {xmin && (
+      {heldBackInfo && (
         <p>
           A long running query on a standby is holding back the xmin horizon at{" "}
-          <code>{xmin}</code>.
+          <code>{heldBackInfo["xmin"]}</code>.
         </p>
       )}
       <p>
@@ -280,9 +277,9 @@ const GuidanceByStandby: React.FunctionComponent<{
 
 const GuidanceByPreparedXact: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number | null;
-}> = ({ inApp, xmin }) => {
-  if (inApp && !xmin) {
+  heldBackInfo: number | null;
+}> = ({ inApp, heldBackInfo }) => {
+  if (inApp && !heldBackInfo) {
     return null;
   }
 
@@ -295,10 +292,10 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
         it is either committed or rolled back.
       </p>
       <h6>Solution</h6>
-      {xmin && (
+      {heldBackInfo && (
         <p>
           A prepared transaction is holding back the xmin horizon at{" "}
-          <code>{xmin}</code>.
+          <code>{heldBackInfo["xmin"]}</code>.
         </p>
       )}
       <p>

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -7,6 +7,7 @@ import {
   CheckTriggerProps,
 } from "../../../util/checks";
 import { useCodeBlock } from "../../CodeBlock";
+import { useSmartAnchor } from "../../SmartAnchor";
 
 const XminHorizonTrigger: React.FunctionComponent<CheckTriggerProps> = ({
   config,
@@ -25,9 +26,9 @@ const XminHorizonTrigger: React.FunctionComponent<CheckTriggerProps> = ({
 };
 
 const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
+  urls: { serverReplicationUrl },
   issue,
 }) => {
-  const CodeBlock = useCodeBlock();
   const issueDetails = issue && JSON.parse(issue.detailsJson);
   const heldBackBy = issueDetails && issueDetails["held_back_by"];
   let byBackend = null;
@@ -59,140 +60,238 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
         When VACUUM is blocked and dead rows can't be cleaned, it can result to
         the unnecessary table bloat or slow queries.
       </p>
-      <h4>Common Causes</h4>
-      <ul>
-        <li>
-          <h5>Long-running transactions</h5>
-          <p>
-            Long-running transactions may still need to access rows that could
-            otherwise be considered dead, so they can block cleanup.
-          </p>
-        </li>
-        <li>
-          <h5>Lagging or stale replication slots</h5>
-          <p>
-            When replication is lagging or a replica server is stale (e.g. down,
-            gone), the oldest transaction that the replication slot needs the
-            database to retain can be "stuck", holding back the xmin horizon.
-            This can also happen to the system catalogs.
-          </p>
-        </li>
-        <li>
-          <h5>Long-running transactions on standbys</h5>
-          <p>
-            When <code>hot_standby_feedback</code> is on, queries on standbys
-            will hold back the xmin horizon just as if they were running on the
-            primary.
-          </p>
-        </li>
-        <li>
-          <h5>Abandoned prepared transactions</h5>
-          <p>
-            A transaction prepared for a two-phase commit will prevent cleanup
-            until it is either committed or rolled back.
-          </p>
-        </li>
-      </ul>
-      {heldBackBy && (
-        <>
-          <h4>Solution</h4>
-          {byBackend && (
-            <>
-              <p>
-                A long running transaction is holding back the xmin horizon at{" "}
-                <code>{byBackend["xmin"]}</code>. You can find this transaction
-                and its connection's pid by running the following command:
-              </p>
-              <CodeBlock>
-                <SQL
-                  sql={`SELECT pid, datname, usename, state, backend_xmin, backend_xid
+      <h4>Common Causes and Solutions</h4>
+      <GuidanceByBackend
+        inApp={!heldBackBy}
+        xmin={byBackend && byBackend["xmin"]}
+      />
+      <GuidanceByReplicationSlot
+        inApp={!heldBackBy}
+        xmin={byReplicationSlot && byReplicationSlot["xmin"]}
+        serverReplicationUrl={serverReplicationUrl}
+      />
+      <GuidanceByReplicationSlotCatalog
+        inApp={!heldBackBy}
+        xmin={byReplicationSlotCatalog && byReplicationSlotCatalog["xmin"]}
+        serverReplicationUrl={serverReplicationUrl}
+      />
+      <GuidanceByStandby
+        inApp={!heldBackBy}
+        xmin={byStandby && byStandby["xmin"]}
+      />
+      <GuidanceByPreparedXact
+        inApp={!heldBackBy}
+        xmin={byPreparedXact && byPreparedXact["xmin"]}
+      />
+    </div>
+  );
+};
+
+const GuidanceByPreparedXact: React.FunctionComponent<{
+  inApp: boolean;
+  xmin: number;
+}> = ({ inApp, xmin }) => {
+  if (!inApp && xmin === null) {
+    return null;
+  }
+
+  const CodeBlock = useCodeBlock();
+  return (
+    <>
+      <h5>Abandoned prepared transactions</h5>
+      <p>
+        A transaction prepared for a two-phase commit will prevent cleanup until
+        it is either committed or rolled back.
+      </p>
+      <h6>Solution</h6>
+      <p>
+        {xmin ??
+          `A prepared transaction is holding back the xmin
+          horizon at
+                ${(<code>{xmin}</code>)}.`}
+        You can find the prepared transaction by running the following command:
+      </p>
+      <CodeBlock>
+        <SQL
+          sql={`SELECT gid, prepared, owner, database, transaction AS xmin
+                  FROM pg_prepared_xacts
+                  ORDER BY age(transaction) DESC;`}
+        />
+      </CodeBlock>
+      <p>
+        Once identified, you can either commit or cancel the transaction with{" "}
+        <SQL inline sql={`COMMIT PREPARED <gid_from_above>`} /> or
+        <SQL inline sql={`ROLLBACK PREPARED <gid_from_above>`} />.
+      </p>
+    </>
+  );
+};
+
+const GuidanceByStandby: React.FunctionComponent<{
+  inApp: boolean;
+  xmin: number;
+}> = ({ inApp, xmin }) => {
+  if (!inApp && xmin === null) {
+    return null;
+  }
+
+  const CodeBlock = useCodeBlock();
+  return (
+    <>
+      <h5>Long-running queries on standbys</h5>
+      <p>
+        When <code>hot_standby_feedback</code> is on with physical streaming
+        replication, queries on standbys will hold back the xmin horizon just as
+        if they were running on the primary.
+      </p>
+      <h6>Solution</h6>
+      <p>
+        {xmin ??
+          `A long running query on a standby is holding back the xmin
+          horizon at
+                ${(<code>{xmin}</code>)}.`}
+        You can find the <code>xmin</code> of all standby servers by running the
+        following command:
+      </p>
+      <CodeBlock>
+        <SQL
+          sql={`SELECT application_name, client_addr, backend_xmin
+                  FROM pg_stat_replication
+                  ORDER BY age(backend_xmin) DESC;`}
+        />
+      </CodeBlock>
+      <p>
+        Once the standby is identified, you can find the query holding back the
+        xmin horizon and its connection's pid in that standby by running the
+        following command:
+      </p>
+      <CodeBlock>
+        <SQL
+          sql={`SELECT pid, datname, usename, state, backend_xmin, backend_xid
                   FROM pg_stat_activity
                   WHERE backend_xmin IS NOT NULL OR backend_xid IS NOT NULL
                   ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
-                />
-              </CodeBlock>
-              <p>
-                You can cancel it with{" "}
-                <SQL inline sql={`SELECT pg_cancel_backend('<query_pid>');`} />{" "}
-                or{" "}
-                <SQL
-                  inline
-                  sql={`SELECT pg_terminate_backend('<query_pid>');`}
-                />
-                .
-              </p>
-            </>
-          )}
-          {byReplicationSlot && (
-            <p>
-              A replication slot is holding back the xmin horizon at{" "}
-              <code>{byReplicationSlot["xmin"]}</code>. This indicates that some
-              physical (streaming) replication slot is likely either lagging or
-              stale (e.g. down, gone). If the replication slot is no longer
-              used, remove it with{" "}
-              <SQL
-                inline
-                sql={`SELECT pg_drop_replication_slot('<slot_name>');`}
-              />
-              .
-            </p>
-          )}
-          {byReplicationSlotCatalog && (
-            <p>
-              The replication slot is holding back the xmin horizon at{" "}
-              <code>{byReplicationSlotCatalog["xmin"]}</code>, specifically with
-              system catalogs. This indicates that the replication slot is
-              either lagging, stale (e.g. down, gone), or having trouble
-              replicating due to schema mismatch. If the replication slot is no
-              longer used, remove it with{" "}
-              <SQL
-                inline
-                sql={`SELECT pg_drop_replication_slot('<slot_name>');`}
-              />
-              .
-            </p>
-          )}
-          {byStandby && (
-            <>
-              <p>
-                A long running transaction on a standby is holding back the xmin
-                horizon at <code>{byStandby["xmin"]}</code>. You can find the{" "}
-                <code>xmin</code> of all standby servers by running the
-                following command:
-              </p>
-              <CodeBlock>
-                <SQL
-                  sql={`SELECT application_name, client_addr, backend_xmin
-                  FROM pg_stat_replication
-                  ORDER BY age(backend_xmin) DESC;`}
-                />
-              </CodeBlock>
-            </>
-          )}
-          {byPreparedXact && (
-            <>
-              <p>
-                A prepared transaction is holding back the xmin horizon at{" "}
-                <code>{byPreparedXact["xmin"]}</code>. You can find this
-                prepared transaction by running the following command:
-              </p>
-              <CodeBlock>
-                <SQL
-                  sql={`SELECT gid, prepared, owner, database, transaction AS xmin
-                  FROM pg_prepared_xacts
-                  ORDER BY age(transaction) DESC;`}
-                />
-              </CodeBlock>
-              <p>
-                Once identified, you can either commit or cancel the transaction
-                with <SQL inline sql={`COMMIT PREPARED <gid_from_above>`} /> or
-                <SQL inline sql={`ROLLBACK PREPARED <gid_from_above>`} />.
-              </p>
-            </>
-          )}
-        </>
-      )}
-    </div>
+        />
+      </CodeBlock>
+    </>
+  );
+};
+
+const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
+  inApp: boolean;
+  xmin: number;
+  serverReplicationUrl: string;
+}> = ({ inApp, xmin, serverReplicationUrl }) => {
+  if (!inApp && xmin === null) {
+    return null;
+  }
+
+  const Link = useSmartAnchor();
+  return (
+    <>
+      <h5>Lagging or stale logical replication slots</h5>
+      <p>
+        With logical replication slots, replication can also get stale when DDL
+        changes (database migrations) don't get applied to a replica server
+        (subscriber). When the subscriber was unable to replicate data due to a
+        schema mismatch, replication will error and get stale. This causes the
+        system catalogs xmin of the primary (publisher) to be held back until
+        replication resumes.
+      </p>
+      <h6>Solution</h6>
+      <p>
+        {xmin ??
+          `A replication slot is holding back the xmin horizon at
+                ${(<code>{xmin}</code>)}, specifically with
+                system catalogs.`}
+        You can check the replication status on the{" "}
+        <Link to={serverReplicationUrl}>Replication</Link> page. You may also
+        want to check logs on both the publisher and the subscriber for any
+        error messages regarding logical replication, such as schema
+        differences.
+      </p>
+      <p>
+        If the replication slot is no longer used, remove it with{" "}
+        <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />.
+      </p>
+    </>
+  );
+};
+
+const GuidanceByReplicationSlot: React.FunctionComponent<{
+  inApp: boolean;
+  xmin: number;
+  serverReplicationUrl: string;
+}> = ({ inApp, xmin, serverReplicationUrl }) => {
+  if (!inApp && xmin === null) {
+    return null;
+  }
+
+  const Link = useSmartAnchor();
+  return (
+    <>
+      <h5>Lagging or stale physical replication slots</h5>
+      <p>
+        With physical streaming replication with{" "}
+        <code>hot_standby_feedback</code> is on, when replication is lagging or
+        a replica server is stale (e.g. down, gone), the oldest transaction that
+        the replication slot needs the database to retain can be "stuck",
+        holding back the xmin horizon.
+      </p>
+      <h6>Solution</h6>
+      <p>
+        {xmin ??
+          `A replication slot is holding back the xmin horizon at
+                ${(<code>{xmin}</code>)}.`}
+        You can check the replication status on the{" "}
+        <Link to={serverReplicationUrl}>Replication</Link> page.
+      </p>
+      <p>
+        If the replication slot is no longer used, remove it with{" "}
+        <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />.
+      </p>
+    </>
+  );
+};
+
+const GuidanceByBackend: React.FunctionComponent<{
+  inApp: boolean;
+  xmin: number;
+}> = ({ inApp, xmin }) => {
+  if (!inApp && xmin === null) {
+    return null;
+  }
+
+  const CodeBlock = useCodeBlock();
+  return (
+    <>
+      <h5>Long-running transactions</h5>
+      <p>
+        Long-running transactions may still need to access rows that could
+        otherwise be considered dead, so they can block cleanup.
+      </p>
+      <h6>Solution</h6>
+      <p>
+        {xmin ??
+          `A long running transaction is holding back the xmin horizon at
+                ${(<code>{xmin}</code>)}.`}
+        You can find the transaction holding back the xmin horizon and its
+        connection's pid by running the following command:
+      </p>
+      <CodeBlock>
+        <SQL
+          sql={`SELECT pid, datname, usename, state, backend_xmin, backend_xid
+                  FROM pg_stat_activity
+                  WHERE backend_xmin IS NOT NULL OR backend_xid IS NOT NULL
+                  ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
+        />
+      </CodeBlock>
+      <p>
+        You can cancel it with{" "}
+        <SQL inline sql={`SELECT pg_cancel_backend('<query_pid>');`} /> or{" "}
+        <SQL inline sql={`SELECT pg_terminate_backend('<query_pid>');`} />.
+      </p>
+    </>
   );
 };
 

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -12,15 +12,15 @@ import { useSmartAnchor } from "../../SmartAnchor";
 const XminHorizonTrigger: React.FunctionComponent<CheckTriggerProps> = ({
   config,
 }) => {
-  const threshold = config.settings["behind_days"] as number;
-  const dayPluralized = threshold === 1 ? "day" : "days";
+  const threshold = config.settings["behind_hours"] as number;
+  const hourPluralized = threshold === 1 ? "hour" : "hours";
   return (
     <p>
-      Detects when the xmin horizon on the server has not progressed for the
-      last <code>{threshold}</code> {dayPluralized} and creates an issue with
+      Detects when the xmin horizon on the server was assigned at more than{" "}
+      <code>{threshold}</code> {hourPluralized} ago and creates an issue with
       severity "info". The issue will be created even if no VACUUM is currently
       blocked by this, as this will potentially block any future VACUUMs.
-      Resolves once the xmin horizon makes some progress.
+      Resolves once the xmin horizon is no longer behind.
     </p>
   );
 };
@@ -84,12 +84,13 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
 
 const GuidanceByBackend: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number;
+  xmin: number | null;
 }> = ({ inApp, xmin }) => {
   if (!inApp && xmin === null) {
     return null;
   }
 
+  const xminCode = <code>{xmin}</code>;
   const CodeBlock = useCodeBlock();
   return (
     <>
@@ -101,9 +102,7 @@ const GuidanceByBackend: React.FunctionComponent<{
       <h6>Solution</h6>
       <p>
         {xmin &&
-          `A long running transaction is holding back the xmin horizon at ${(
-            <code>{xmin}</code>
-          )}.`}
+          `A long running transaction is holding back the xmin horizon at ${xminCode}.`}
         You can find the transaction holding back the xmin horizon and its
         connection's pid by running the following command:
       </p>
@@ -126,13 +125,14 @@ const GuidanceByBackend: React.FunctionComponent<{
 
 const GuidanceByReplicationSlot: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number;
+  xmin: number | null;
   serverReplicationUrl: string;
 }> = ({ inApp, xmin, serverReplicationUrl }) => {
   if (!inApp && xmin === null) {
     return null;
   }
 
+  const xminCode = <code>{xmin}</code>;
   const Link = useSmartAnchor();
   return (
     <>
@@ -147,9 +147,7 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
       <h6>Solution</h6>
       <p>
         {xmin &&
-          `A replication slot is holding back the xmin horizon at ${(
-            <code>{xmin}</code>
-          )}.`}
+          `A replication slot is holding back the xmin horizon at ${xminCode}.`}
         You can check the replication status on the{" "}
         <Link to={serverReplicationUrl}>Replication</Link> page.
       </p>
@@ -163,13 +161,14 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
 
 const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number;
+  xmin: number | null;
   serverReplicationUrl: string;
 }> = ({ inApp, xmin, serverReplicationUrl }) => {
   if (!inApp && xmin === null) {
     return null;
   }
 
+  const xminCode = <code>{xmin}</code>;
   const Link = useSmartAnchor();
   return (
     <>
@@ -185,9 +184,7 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
       <h6>Solution</h6>
       <p>
         {xmin &&
-          `A replication slot is holding back the xmin horizon at ${(
-            <code>{xmin}</code>
-          )}, specifically with system catalogs.`}
+          `A replication slot is holding back the xmin horizon at ${xminCode}, specifically with system catalogs.`}
         You can check the replication status on the{" "}
         <Link to={serverReplicationUrl}>Replication</Link> page. You may also
         want to check logs on both the publisher and the subscriber for any
@@ -204,12 +201,13 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
 
 const GuidanceByStandby: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number;
+  xmin: number | null;
 }> = ({ inApp, xmin }) => {
   if (!inApp && xmin === null) {
     return null;
   }
 
+  const xminCode = <code>{xmin}</code>;
   const CodeBlock = useCodeBlock();
   return (
     <>
@@ -221,10 +219,10 @@ const GuidanceByStandby: React.FunctionComponent<{
       </p>
       <h6>Solution</h6>
       <p>
-        {xmin ??
+        {xmin &&
           `A long running query on a standby is holding back the xmin
           horizon at
-                ${(<code>{xmin}</code>)}.`}
+                ${xminCode}.`}
         You can find the <code>xmin</code> of all standby servers by running the
         following command:
       </p>
@@ -254,12 +252,13 @@ const GuidanceByStandby: React.FunctionComponent<{
 
 const GuidanceByPreparedXact: React.FunctionComponent<{
   inApp: boolean;
-  xmin: number;
+  xmin: number | null;
 }> = ({ inApp, xmin }) => {
   if (!inApp && xmin === null) {
     return null;
   }
 
+  const xminCode = <code>{xmin}</code>;
   const CodeBlock = useCodeBlock();
   return (
     <>
@@ -271,9 +270,7 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
       <h6>Solution</h6>
       <p>
         {xmin &&
-          `A prepared transaction is holding back the xmin horizon at ${(
-            <code>{xmin}</code>
-          )}.`}
+          `A prepared transaction is holding back the xmin horizon at ${xminCode}.`}
         You can find the prepared transaction by running the following command:
       </p>
       <CodeBlock>
@@ -285,7 +282,7 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
       </CodeBlock>
       <p>
         Once identified, you can either commit or cancel the transaction with{" "}
-        <SQL inline sql={`COMMIT PREPARED <gid_from_above>`} /> or
+        <SQL inline sql={`COMMIT PREPARED <gid_from_above>`} /> or{" "}
         <SQL inline sql={`ROLLBACK PREPARED <gid_from_above>`} />.
       </p>
     </>
@@ -294,7 +291,7 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
 
 const documentation: CheckDocs = {
   description:
-    "Monitors the xmin horizon of the server and creates an info issue if the xmin horizon is not making any progress.",
+    "Monitors the xmin horizon of the server and creates an info issue if the xmin horizon is behind.",
   Trigger: XminHorizonTrigger,
   Guidance: XminHorizonGuidance,
 };

--- a/components/CheckDocumentation/vacuum/XminHorizonBehind.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizonBehind.tsx
@@ -1,0 +1,170 @@
+import SQL from "../../SQL";
+import React from "react";
+
+import {
+  CheckDocs,
+  CheckGuidanceProps,
+  CheckTriggerProps,
+} from "../../../util/checks";
+import { useCodeBlock } from "../../CodeBlock";
+
+const XminHorizonBehindTrigger: React.FunctionComponent<CheckTriggerProps> = ({
+  config,
+}) => {
+  const threshold = config.settings["behind_days"] as number;
+  const dayPluralized = threshold === 1 ? "day" : "days";
+  return (
+    <p>
+      Detects when the xmin horizon on the server has not progressed for the
+      last <code>{threshold}</code> {dayPluralized} and creates an issue with
+      severity "info". Resolves once the xmin horizon makes some progress.
+    </p>
+  );
+};
+
+const XminHorizonBehindGuidance: React.FunctionComponent<
+  CheckGuidanceProps
+> = ({ issue }) => {
+  const CodeBlock = useCodeBlock();
+  const issueDetails = issue && JSON.parse(issue.detailsJson);
+  const heldBackBy = issueDetails && issueDetails["held_back_by"];
+  return (
+    <div>
+      <h4>Impact</h4>
+      <p>
+        The xmin horizon tells you until which point the vacuum process can
+        clean up dead rows. When this value is behind and not making progress,
+        it's very likely that VACUUM can't clean up dead rows, or process
+        freezing.
+      </p>
+      <p>
+        When dead rows can't be cleaned, it can result to the unnecessary table
+        bloat or slow queries. If freezing is not happening in timely manner, it
+        can result to the transaction wraparound, in the worst case scenario.
+      </p>
+      <h4>Common Causes</h4>
+      <li>
+        <h5>Long-running transactions</h5>
+        <p>
+          When there is a long running transaction, you can't clean up rows that
+          the transaction can see, even if it already became a dead row.
+        </p>
+      </li>
+      <li>
+        <h5>Unfinished prepared transactions</h5>
+        <p>
+          If the transaction prepared for a two-phase commit is unfinished and
+          kept around, it can become the oldest xmin.
+        </p>
+      </li>
+      <li>
+        <h5>Delayed/bad replication slots</h5>
+        <p>
+          When the replication is delayed or the standby server is down, the
+          oldest transaction that the replication slot needs the database to
+          retain can be "stuck" hence hold back of the xmin horizon can happen.
+          This can also happen to the system catalogs.
+        </p>
+      </li>
+      <li>
+        <h5>Long-running transactions on standbys</h5>
+        <p>
+          When <code>hot_standby_feedback</code> is on, queries on standbys will
+          act the same as primary regarding the xmin horizon, and causes the
+          xmin horizon to be behind.
+        </p>
+      </li>
+      <h4>Solution</h4>
+      {heldBackBy["backend"] && (
+        <>
+          <p>
+            The long running transaction is holding back the xmin horizon at{" "}
+            <code>{heldBackBy["backend"]}</code>. You can find such transaction
+            and its pid by running the following command:
+          </p>
+          <CodeBlock>
+            <SQL
+              inline
+              sql={`SELECT pid, datname, usename, state, backend_xmin, backend_xid
+                  FROM pg_stat_activity
+                  WHERE backend_xmin IS NOT NULL OR backend_xid IS NOT NULL
+                  ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
+            />
+          </CodeBlock>
+          <p>
+            You can cancel it with{" "}
+            <SQL inline sql={`SELECT pg_cancel_backend('<query_pid>');`} /> or{" "}
+            <SQL inline sql={`SELECT pg_terminate_backend('<query_pid>');`} />
+          </p>
+        </>
+      )}
+      {heldBackBy["replication_slot"] && (
+        <p>
+          The replication slot is holding back the xmin horizon at{" "}
+          <code>{heldBackBy["replication_slot"]}</code>. This indicates that
+          some physical (streaming) replication slot is likely either delayed or
+          down. If the replication slot is no longer used, remove it with{" "}
+          <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />
+        </p>
+      )}
+      {heldBackBy["replication_slot_catalog"] && (
+        <p>
+          The replication slot is holding back the xmin horizon at{" "}
+          <code>{heldBackBy["replication_slot_catalog"]}</code>, specifically
+          with the system catalogs. This indicates that the replication slot is
+          either delayed, down, or having trouble replicating due to schema
+          mismatch. If the replication slot is no longer used, remove it with{" "}
+          <SQL inline sql={`SELECT pg_drop_replication_slot('<slot_name>');`} />
+        </p>
+      )}
+      {heldBackBy["standby"] && (
+        <>
+          <p>
+            The long running transaction on the standby is holding back the xmin
+            horizon at <code>{heldBackBy["standby"]}</code>. You can find the{" "}
+            <code>xmin</code> of all standby servers by running the following
+            command:
+          </p>
+          <CodeBlock>
+            <SQL
+              inline
+              sql={`SELECT application_name, client_addr, backend_xmin
+                  FROM pg_stat_replication
+                  ORDER BY age(backend_xmin) DESC;`}
+            />
+          </CodeBlock>
+        </>
+      )}
+      {heldBackBy["prepared_xact"] && (
+        <>
+          <p>
+            The orphaned prepared transaction is holding back the xmin horizon
+            at <code>{heldBackBy["prepared_xact"]}</code>. You can find such
+            prepared transactions by running the following command:
+          </p>
+          <CodeBlock>
+            <SQL
+              inline
+              sql={`SELECT gid, prepared, owner, database, transaction AS xmin
+                  FROM pg_prepared_xacts
+                  ORDER BY age(transaction) DESC;`}
+            />
+          </CodeBlock>
+          <p>
+            Once identified, you can cancel the transaction with{" "}
+            <SQL inline sql={`ROLLBACK PREPARED <gid_from_above>`} />.
+          </p>
+        </>
+      )}
+    </div>
+  );
+};
+
+const documentation: CheckDocs = {
+  description:
+    "Monitors the xmin horizon of the server and creates an info issue if the xmin horizon is not making any progress.",
+  Trigger: XminHorizonBehindTrigger,
+  Guidance: XminHorizonBehindGuidance,
+};
+
+export default documentation;

--- a/components/CheckDocumentation/vacuum/XminHorizonBehind.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizonBehind.tsx
@@ -43,37 +43,39 @@ const XminHorizonBehindGuidance: React.FunctionComponent<
         can result to the transaction wraparound, in the worst case scenario.
       </p>
       <h4>Common Causes</h4>
-      <li>
-        <h5>Long-running transactions</h5>
-        <p>
-          When there is a long running transaction, you can't clean up rows that
-          the transaction can see, even if it already became a dead row.
-        </p>
-      </li>
-      <li>
-        <h5>Unfinished prepared transactions</h5>
-        <p>
-          If the transaction prepared for a two-phase commit is unfinished and
-          kept around, it can become the oldest xmin.
-        </p>
-      </li>
-      <li>
-        <h5>Delayed/bad replication slots</h5>
-        <p>
-          When the replication is delayed or the standby server is down, the
-          oldest transaction that the replication slot needs the database to
-          retain can be "stuck" hence hold back of the xmin horizon can happen.
-          This can also happen to the system catalogs.
-        </p>
-      </li>
-      <li>
-        <h5>Long-running transactions on standbys</h5>
-        <p>
-          When <code>hot_standby_feedback</code> is on, queries on standbys will
-          act the same as primary regarding the xmin horizon, and causes the
-          xmin horizon to be behind.
-        </p>
-      </li>
+      <ul>
+        <li>
+          <h5>Long-running transactions</h5>
+          <p>
+            When there is a long running transaction, you can't clean up rows
+            that the transaction can see, even if it already became a dead row.
+          </p>
+        </li>
+        <li>
+          <h5>Unfinished prepared transactions</h5>
+          <p>
+            If the transaction prepared for a two-phase commit is unfinished and
+            kept around, it can become the oldest xmin.
+          </p>
+        </li>
+        <li>
+          <h5>Delayed/bad replication slots</h5>
+          <p>
+            When the replication is delayed or the standby server is down, the
+            oldest transaction that the replication slot needs the database to
+            retain can be "stuck" hence hold back of the xmin horizon can
+            happen. This can also happen to the system catalogs.
+          </p>
+        </li>
+        <li>
+          <h5>Long-running transactions on standbys</h5>
+          <p>
+            When <code>hot_standby_feedback</code> is on, queries on standbys
+            will act the same as primary regarding the xmin horizon, and causes
+            the xmin horizon to be behind.
+          </p>
+        </li>
+      </ul>
       <h4>Solution</h4>
       {heldBackBy["backend"] && (
         <>
@@ -84,7 +86,6 @@ const XminHorizonBehindGuidance: React.FunctionComponent<
           </p>
           <CodeBlock>
             <SQL
-              inline
               sql={`SELECT pid, datname, usename, state, backend_xmin, backend_xid
                   FROM pg_stat_activity
                   WHERE backend_xmin IS NOT NULL OR backend_xid IS NOT NULL
@@ -127,7 +128,6 @@ const XminHorizonBehindGuidance: React.FunctionComponent<
           </p>
           <CodeBlock>
             <SQL
-              inline
               sql={`SELECT application_name, client_addr, backend_xmin
                   FROM pg_stat_replication
                   ORDER BY age(backend_xmin) DESC;`}
@@ -144,7 +144,6 @@ const XminHorizonBehindGuidance: React.FunctionComponent<
           </p>
           <CodeBlock>
             <SQL
-              inline
               sql={`SELECT gid, prepared, owner, database, transaction AS xmin
                   FROM pg_prepared_xacts
                   ORDER BY age(transaction) DESC;`}

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -249,7 +249,7 @@ export const DEFAULT_CHECK_CONFIGS: DefaultCheckConfigs = {
     xmin_horizon: {
       enabled: true,
       settings: {
-        behind_days: 1,
+        behind_hours: 24,
       }
     },
   },

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -296,6 +296,7 @@ export type IssueGuidanceUrls = {
   databaseTableUrl: string;
   serverLogInsightsUrl: string;
   serverSchemaUrl: string;
+  serverReplicationUrl: string;
   featureUrl: (mainUrl: string | undefined, section: string) => string | undefined;
 };
 

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -30,7 +30,11 @@ export const CHECK_TITLES = {
   },
   vacuum: {
     inefficient_index_phase: "VACUUM - Inefficient index phase",
+<<<<<<< HEAD
     insufficient_vacuum_frequency: "VACUUM: Bloat - Insufficient VACUUM Frequency",
+=======
+    xmin_horizon: "VACUUM - Xmin horizon behind",
+>>>>>>> 28c6c3f (Add initial version)
   },
 };
 
@@ -66,7 +70,11 @@ export const CHECK_SEVERITIES = {
   },
   vacuum: {
     inefficient_index_phase: ['warning'],
+<<<<<<< HEAD
     insufficient_vacuum_frequency: ['info'],
+=======
+    xmin_horizon: ['info'],
+>>>>>>> 28c6c3f (Add initial version)
   },
 }
 
@@ -126,7 +134,11 @@ export const CHECK_FREQUENCY = {
   },
   vacuum: {
     inefficient_index_phase: CHECK_FREQUENCY_DAILY,
+<<<<<<< HEAD
     insufficient_vacuum_frequency: CHECK_FREQUENCY_DAILY,
+=======
+    xmin_horizon: CHECK_FREQUENCY_DAILY,
+>>>>>>> 28c6c3f (Add initial version)
   },
 };
 
@@ -241,6 +253,12 @@ export const DEFAULT_CHECK_CONFIGS: DefaultCheckConfigs = {
       settings: {
         notify_pct: 20,
         notify_bytes: 10 * 1024 * 1024,
+      }
+    },
+    xmin_horizon: {
+      enabled: true,
+      settings: {
+        behind_days: 1,
       }
     },
   },

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -29,12 +29,9 @@ export const CHECK_TITLES = {
     follower_missing: "Replication - Missing HA Follower",
   },
   vacuum: {
-    inefficient_index_phase: "VACUUM - Inefficient index phase",
-<<<<<<< HEAD
+    inefficient_index_phase: 'VACUUM: Capacity & Overhead - Inefficient index phase',
     insufficient_vacuum_frequency: "VACUUM: Bloat - Insufficient VACUUM Frequency",
-=======
-    xmin_horizon: "VACUUM - Xmin horizon behind",
->>>>>>> 28c6c3f (Add initial version)
+    xmin_horizon: 'VACUUM: Bloat - VACUUM Blocked By Xmin Horizon'
   },
 };
 
@@ -70,11 +67,8 @@ export const CHECK_SEVERITIES = {
   },
   vacuum: {
     inefficient_index_phase: ['warning'],
-<<<<<<< HEAD
     insufficient_vacuum_frequency: ['info'],
-=======
     xmin_horizon: ['info'],
->>>>>>> 28c6c3f (Add initial version)
   },
 }
 
@@ -134,11 +128,8 @@ export const CHECK_FREQUENCY = {
   },
   vacuum: {
     inefficient_index_phase: CHECK_FREQUENCY_DAILY,
-<<<<<<< HEAD
     insufficient_vacuum_frequency: CHECK_FREQUENCY_DAILY,
-=======
     xmin_horizon: CHECK_FREQUENCY_DAILY,
->>>>>>> 28c6c3f (Add initial version)
   },
 };
 


### PR DESCRIPTION
Add a check guidance for "VACUUM: Bloat - VACUUM Blocked By Xmin Horizon" check. The below shows all 5 causes, but in app, we will only show the specific cause that triggered a check.

In the check configuration, there is a blank "hours ago" but it's just due to some browser cache problem, it's implemented okay.

![image](https://github.com/pganalyze/pganalyze-docs/assets/911433/95ad9cc7-72f0-490e-824b-037ad7aafb04)
