### PR TITLE
Show the link to Index Advisor doc from MissingIndexGuidance

### DIFF
--- a/components/CheckDocumentation/index_advisor/MissingIndex.tsx
+++ b/components/CheckDocumentation/index_advisor/MissingIndex.tsx
@@ -1,26 +1,43 @@
 import React from "react";
 
-import { CheckDocs, CheckGuidanceProps, CheckTriggerProps } from "../../../util/checks";
+import {
+  CheckDocs,
+  CheckGuidanceProps,
+  CheckTriggerProps,
+} from "../../../util/checks";
 
 const MissingIndexTrigger: React.FunctionComponent<CheckTriggerProps> = () => {
   return (
     <p>
-      Detects when a table might be missing an index based on the query workload over the last
-      seven days and creates an issue with severity "info". Resolves once the recommended index
-      has been created, or the workload has changed such that the index is no longer relevant.
+      Detects when a table might be missing an index based on the query workload
+      over the last seven days and creates an issue with severity "info".
+      Resolves once the recommended index has been created, or the workload has
+      changed such that the index is no longer relevant.
     </p>
   );
 };
 
-const MissingIndexGuidance: React.FunctionComponent<CheckGuidanceProps> = () => {
-  // TODO: the Missing Index check has dynamic guidance, so this component is not used in-app,
-  // but we still need something for the public documentation (possibly linking to other Index
-  // Advisor docs).
-  return null;
+const MissingIndexGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
+  issue,
+}) => {
+  if (issue) {
+    // The Missing Index check has dynamic guidance, so this component is not used in-app (aka when `issue` is present)
+    return null;
+  }
+  return (
+    <p>
+      You can learn about Index Advisor and missing index opportunities in{" "}
+      <a href="https://pganalyze.com/docs/index-advisor/reason-about-opportunities">
+        Index Advisor documentation
+      </a>
+      .
+    </p>
+  );
 };
 
 const documentation: CheckDocs = {
-  description: "Detects when a table might be missing an index based on the query workload.",
+  description:
+    "Detects when a table might be missing an index based on the query workload.",
   Trigger: MissingIndexTrigger,
   Guidance: MissingIndexGuidance,
 };

--- a/components/CheckDocumentation/index_advisor/MissingIndex.tsx
+++ b/components/CheckDocumentation/index_advisor/MissingIndex.tsx
@@ -28,7 +28,7 @@ const MissingIndexGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
     <p>
       You can learn about Index Advisor and missing index opportunities in{" "}
       <a href="https://pganalyze.com/docs/index-advisor/reason-about-opportunities">
-        Index Advisor documentation
+        the Index Advisor documentation
       </a>
       .
     </p>


### PR DESCRIPTION
Currently, we don't have anything under "Guidance" of Missing Index check in docs. This PR adds the link to Index Advisor page.

https://pganalyze.com/docs/checks/index_advisor/missing_index
https://pganalyze-we-update-doc-6cg6ik.herokuapp.com/docs/checks/index_advisor/missing_index