### PR TITLE
Update insufficient VACUUM frequency guidance in docs page side

### DIFF
--- a/components/CheckDocumentation/vacuum/InsufficientVacuumFrequency.tsx
+++ b/components/CheckDocumentation/vacuum/InsufficientVacuumFrequency.tsx
@@ -37,7 +37,7 @@ const InsufficientVacuumFrequencyGuidance: React.FunctionComponent<
       <a href="https://pganalyze.com/docs/vacuum-advisor/bloat">
         the VACUUM Advisor documentation
       </a>
-      . You can also learn more about bloat in general in a{" "}
+      . You can also learn more about bloat in general by reading about{" "}
       <a href="https://pganalyze.com/docs/vacuum-advisor/bloat-in-postgres">
         Bloat in Postgres
       </a>

--- a/components/CheckDocumentation/vacuum/InsufficientVacuumFrequency.tsx
+++ b/components/CheckDocumentation/vacuum/InsufficientVacuumFrequency.tsx
@@ -24,9 +24,26 @@ const InsufficientVacuumFrequencyTrigger: React.FunctionComponent<
 
 const InsufficientVacuumFrequencyGuidance: React.FunctionComponent<
   CheckGuidanceProps
-> = () => {
-  // InsufficientVacuumFrequency uses a similar pattern as MissingIndex.
-  return null;
+> = ({ issue }) => {
+  if (issue) {
+    // The InsufficientVacuumFrequency check has dynamic guidance
+    // so this component is not used in-app (aka when `issue` is present)
+    return null;
+  }
+  return (
+    <p>
+      You can learn about VACUUM Advisor and insufficient VACUUM frequency
+      insights in{" "}
+      <a href="https://pganalyze.com/docs/vacuum-advisor/bloat">
+        the VACUUM Advisor documentation
+      </a>
+      . You can also learn more about bloat in general in a{" "}
+      <a href="https://pganalyze.com/docs/vacuum-advisor/bloat-in-postgres">
+        Bloat in Postgres
+      </a>
+      .
+    </p>
+  );
 };
 
 const documentation: CheckDocs = {


### PR DESCRIPTION
Currently, the doc https://pganalyze.com/docs/checks/vacuum/insufficient_vacuum_frequency doesn't have anything under Guidance. This PR is going to add something there.

This will depend on https://github.com/pganalyze/pganalyze-docs/pull/160 and also the PR Lukas will open shortly.