### PR TITLE
Add the explanation that the xmin horizon is server wide

### DIFF
--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -67,6 +67,15 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
         When VACUUM is blocked and dead rows can't be cleaned, it can result in
         table bloat and slow queries.
       </p>
+      <p>
+        This xmin horizon is the oldest xmin of the server. While the xmin
+        horizon could block dead rows to be cleaned, it's not necessary that all
+        tables of the server will be impacted. Postgres can still clean up dead
+        rows of tables that are unrelated to the xmin horizon. For example, if
+        the xmin horizon is held back by the long running transaction of
+        database1, Postgres can still clean up dead rows of tables in database2,
+        as the transaction of database1 will never be able to see database2.
+      </p>
       <h4>{causeTitle}</h4>
       <ul>
         <GuidanceByBackend inApp={inApp} heldBackInfo={byBackend} />

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -68,13 +68,15 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
         table bloat and slow queries.
       </p>
       <p>
-        This xmin horizon is the oldest xmin of the server. While the xmin
-        horizon could block dead rows to be cleaned, it's not necessary that all
-        tables of the server will be impacted. Postgres can still clean up dead
-        rows of tables that are unrelated to the xmin horizon. For example, if
-        the xmin horizon is held back by the long running transaction of
-        database1, Postgres can still clean up dead rows of tables in database2,
-        as the transaction of database1 will never be able to see database2.
+        The xmin horizon tracked by pganalyze is the oldest xmin across all
+        databases, summarized as a server-wide metric. Note that while some
+        types of xmin horizon delays affect all databases on a server, such as
+        the xmin for each physical replication slots, in other cases not all
+        databases of a server will be impacted, as Postgres can still clean up
+        dead rows of tables on unrelated databases. For example, if the xmin
+        horizon is held back by a long running transaction on database1,
+        Postgres can still clean up dead rows of tables in database2, as the
+        transaction of database1 will never be able to see database2.
       </p>
       <h4>{causeTitle}</h4>
       <ul>


### PR DESCRIPTION
Looking at the following note from Matthias van de Meent, it is clear that the xmin horizon won't block _every_ vacuum.
https://www.postgresql.org/message-id/CAEze2WjJZZ=P_ich+=RiA51APHsNV7zi=-j-24DCPsaV43c+Ow@mail.gmail.com

We should make it clear in some place, we can start from the xmin horizon check doc.