### PR TITLE
Rename 'collector hangs' troubleshooting page

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -708,9 +708,9 @@
       "title": "Collector crashes",
       "path": "/docs/install/troubleshooting/collector_crash"
     },
-    "install/troubleshooting/collector_hang": {
-      "title": "Collector hangs",
-      "path": "/docs/install/troubleshooting/collector_hang"
+    "install/troubleshooting/collector_times_out": {
+      "title": "Collector times out",
+      "path": "/docs/install/troubleshooting/collector_times_out"
     },
     "install/troubleshooting/column_stats_helper": {
       "title": "Resolving the \"Limited access to table column statistics\" warning",

--- a/install/troubleshooting.mdx
+++ b/install/troubleshooting.mdx
@@ -7,6 +7,6 @@ backlink_title: 'Installation Guide'
 This section provides helpful information about troubleshooting your pganalyze installation:
 
  * [Collector crashing](/docs/install/troubleshooting/collector_crash)
- * [Collector hanging](/docs/install/troubleshooting/collector_hang)
+ * [Collector times out](/docs/install/troubleshooting/collector_times_out)
  * [Amazon RDS: Resolving the "pg\_stat\_statements must be loaded via shared\_preload\_libraries" error](/docs/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries)
  * [Resolving the "Limited access to table column statistics" warning](/docs/install/troubleshooting/column_stats_helper)

--- a/install/troubleshooting/collector_times_out.mdx
+++ b/install/troubleshooting/collector_times_out.mdx
@@ -1,12 +1,14 @@
 ---
-title: Collector hangs
+title: Collector times out
 backlink_href: /docs/install/troubleshooting
 backlink_title: 'Installation Troubleshooting'
 ---
 
-If you find the collector hanging either periodically or constantly, or even within the test run,
-the most likely cause is `pg_stat_statements` statistic data being big and taking long time to query the statistic from it.
-This especially happens when there are many queries with long query texts.
+If you find the collector timing out or hanging, either periodically or
+constantly, or even within the test run, the most likely cause is
+`pg_stat_statements` statistic data being big and taking long time to query the
+statistic from it. This especially happens when there are many queries with long
+query texts.
 
 You can check out below points using the following query to identify if ps_stat_statements statistic data is big or not.
 
@@ -22,11 +24,15 @@ SELECT
 FROM pg_stat_statements;
 ```
 
-To mitigate the issue, you can run `SELECT pg_stat_statements_reset()` to reset the statistics data.
-This will not affect the statistics data tracked within pganalyze, but if you are using other tools that rely on `pg_stat_statements` data, you should review how they will be affected.
-If the collector test run (`pganalyze-collector --test --verbose`) is already hanging, it's good to try this out and see if it resolves the problem.
+To mitigate the issue, you can run `SELECT pg_stat_statements_reset()` to reset
+the statistics data. This will not affect the statistics data tracked within
+pganalyze, but if you are using other tools that rely on `pg_stat_statements`
+data, you should review how they will be affected. If the collector test run
+(`pganalyze-collector --test --verbose`) is already timing out or hanging, it's
+good to try this out and see if it resolves the problem.
 
-If the collector still hangs after this, please [contact us](/contact) so that we can help debug further.
+If the collector still times out or hangs after this, please [contact
+us](/contact) so that we can help debug further.
 
 Once you confirm that `pg_stat_statements_reset()` is a valid mitigation, you can enable a recurring reset executed by pganalyze.
 

--- a/install/troubleshooting/toc.yml
+++ b/install/troubleshooting/toc.yml
@@ -2,8 +2,8 @@
   items:
   - name: Collector crashes
     href: install/troubleshooting/collector_crash
-  - name: Collector hangs
-    href: install/troubleshooting/collector_hang
+  - name: Collector times out
+    href: install/troubleshooting/collector_times_out
   - name: 'Resolving the "Limited access to table column statistics" warning'
     href: install/troubleshooting/column_stats_helper
   - name: Resolving the 'permission denied to create extension "pg_stat_statements"' error


### PR DESCRIPTION
Name this 'collector times out' instead, since this may be more
recognizable, and with improved handling of timeout intervals in the
collector, this is the more likely symptom now.
