### PR TITLE
Enterprise setup docs: Increase minimum Postgres version to 11

### DIFF
--- a/enterprise/setup/index.mdx
+++ b/enterprise/setup/index.mdx
@@ -22,7 +22,7 @@ The pganalyze container image is mostly self-contained, and runs various service
   * pganalyze Enterprise Server is delivered as a container image compatible with Docker / podman
   * When using podman, make sure to replace `docker` with `podman` in the steps below
 * Setup a PostgreSQL database that can be used for storing statistics data
-  * PostgreSQL 10 or newer is required
+  * PostgreSQL 11 or newer is required
   * 50 GB of dedicated disk space or more
 * Optional: If you use the RDS integration, set up an appropriate IAM role that can be used to download logs and system metrics
   * You can also assign the required policy to an existing EC2 instance and its instance role


### PR DESCRIPTION
This has been required since v2023.08.0.