### PR TITLE
Enterprsie S3 object storage: Clarify where the configuration is set

### DIFF
--- a/enterprise/setup/object-storage-s3.mdx
+++ b/enterprise/setup/object-storage-s3.mdx
@@ -64,7 +64,7 @@ You will also need to assign this IAM user as a "Key User" to the KMS key.
 
 ## 3. Configuration on pganalyze Docker container
 
-You will need to add the following configuration to the Docker container:
+You will need to add the following configuration to the Docker container. If running pganalyze Enterprise Server in a VM, you need to add this to the `/etc/pganalyze.env` file.
 
 ```sh
 AWS_REGION=us-east-1
@@ -73,7 +73,7 @@ AWS_S3_LOGS_BUCKET=mydb-logs
 AWS_KMS_LOGS_CMK=...
 ```
 
-By default pganalyze will attempt IAM authentication using the AWS metadata service / instance roles. If you want to use static keys you can set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables.
+By default pganalyze will attempt IAM authentication using the AWS metadata service / instance roles. If you want to use static keys you can set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables, see the [Enterprise Server container settings](/docs/enterprise/settings).
 
 The `AWS_KMS_LOGS_CMK` is the "ARN" thats listed on the encryption key.
 


### PR DESCRIPTION
There was an occurrence where someone accidentally thought these are set in the collector configuration. Given our recent standardization around always using "/etc/pganalyze.env" as the source for Docker environment settings when running in a VM, reference that here explicitly in an effort to help understand the instructions better.

In passing link to Enterprise Server container settings page when talking about the settings for static AWS credentials.