### PR TITLE
Improve Xmin horizon check details

### DIFF
--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -129,18 +129,11 @@ function formatFullTransactionID(value: number): string {
   return `${epoch}:${xid}`;
 }
 
-const XminHeldBackInfo: React.FunctionComponent<{
-  type: string;
+const XminHeldBackPoint: React.FunctionComponent<{
   info: HeldBackInfoType;
-}> = ({ type, info }) => {
+}> = ({ info }) => {
   const fullTxid = formatFullTransactionID(info["xmin"]);
-
-  return (
-    <>
-      A {type} is holding back the xmin horizon at{" "}
-      <code>{`${fullTxid}`}</code> (assigned at {new Date(info["assigned_at"] * 1000).toISOString()})
-    </>
-  );
+  return <code>{`${fullTxid}`}</code>;
 }
 
 const GuidanceByBackend: React.FunctionComponent<{
@@ -164,7 +157,8 @@ const GuidanceByBackend: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          <XminHeldBackInfo type="long-running transaction" info={heldBackInfo} />.
+          A long-running transaction is holding back the xmin horizon at{" "}
+          <XminHeldBackPoint info={heldBackInfo} />.
         </p>
       )}
       <p>
@@ -187,7 +181,7 @@ const GuidanceByBackend: React.FunctionComponent<{
       <CodeBlock>
         <SQL sql={`SELECT pg_terminate_backend('<query_pid>');`} />
       </CodeBlock>
-      <p>Note this will roll back the transaction, and <strong>discard all data written to the database earlier within that transaction</strong>.</p>
+      <p>Note this will roll back the transaction, and <strong>discard all data</strong> written to the database earlier within that transaction.</p>
     </li>
   );
 };
@@ -218,7 +212,8 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          <XminHeldBackInfo type="replication slot" info={heldBackInfo} />.
+          A replication slot is holding back the xmin horizon at{" "}
+          <XminHeldBackPoint info={heldBackInfo} />.
         </p>
       )}
       <p>
@@ -263,7 +258,8 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          <XminHeldBackInfo type="replication slot" info={heldBackInfo} />,
+          A replication slot is holding back the xmin horizon at{" "}
+          <XminHeldBackPoint info={heldBackInfo} />,
           specifically with system catalogs.
         </p>
       )}
@@ -307,7 +303,8 @@ const GuidanceByStandby: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          <XminHeldBackInfo type="long running query on a standby" info={heldBackInfo} />.
+          A long running query on a standby is holding back the xmin horizon at{" "}
+          <XminHeldBackPoint info={heldBackInfo} />.
         </p>
       )}
       <p>
@@ -364,7 +361,8 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          <XminHeldBackInfo type="prepared transaction" info={heldBackInfo} />.
+          A prepared transaction is holding back the xmin horizon at{" "}
+          <XminHeldBackPoint info={heldBackInfo} />.
         </p>
       )}
       <p>

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../../util/checks";
 import { useCodeBlock } from "../../CodeBlock";
 import { useSmartAnchor } from "../../SmartAnchor";
+import PGDocsLink from "../../PGDocsLink";
 
 const XminHorizonTrigger: React.FunctionComponent<CheckTriggerProps> = ({
   config,
@@ -173,11 +174,11 @@ const GuidanceByBackend: React.FunctionComponent<{
                   ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
         />
       </CodeBlock>
-      <p>You can cancel it by running either <a href="https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL" target="_blank">pg_cancel_backend</a> if the transaction is running an active query:</p>
+      <p>You can cancel it by running either <PGDocsLink path="/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL">pg_cancel_backend</PGDocsLink> if the transaction is running an active query:</p>
       <CodeBlock>
         <SQL sql={`SELECT pg_cancel_backend('<query_pid>');`} />
       </CodeBlock>
-      <p>or <a href="https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL" target="_blank">pg_terminate_backend</a> if the connection state is "idle in transaction".</p>
+      <p>or <PGDocsLink path="/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL">pg_terminate_backend</PGDocsLink> if the connection state is "idle in transaction".</p>
       <CodeBlock>
         <SQL sql={`SELECT pg_terminate_backend('<query_pid>');`} />
       </CodeBlock>
@@ -348,12 +349,11 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
     <li>
       <h5>Abandoned prepared transactions</h5>
       <p>
-        <a
-          href="https://www.postgresql.org/docs/current/sql-prepare-transaction.html"
-          target="_blank"
+        <PGDocsLink
+          path="/sql-prepare-transaction.html"
         >
           A transaction prepared for a two-phase commit
-        </a>{" "}
+        </PGDocsLink>{" "}
         will prevent cleanup until it is either committed or rolled back.
       </p>
       <h6>

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -173,10 +173,15 @@ const GuidanceByBackend: React.FunctionComponent<{
                   ORDER BY greatest(age(backend_xmin), age(backend_xid)) DESC;`}
         />
       </CodeBlock>
-      <p>You can cancel it by running either of commands:</p>
+      <p>You can cancel it by running either <a href="https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL" target="_blank">pg_cancel_backend</a> if the transaction is running an active query:</p>
       <CodeBlock>
         <SQL sql={`SELECT pg_cancel_backend('<query_pid>');`} />
       </CodeBlock>
+      <p>or <a href="https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL" target="_blank">pg_terminate_backend</a> if the connection state is "idle in transaction".</p>
+      <CodeBlock>
+        <SQL sql={`SELECT pg_terminate_backend('<query_pid>');`} />
+      </CodeBlock>
+      <p>Note this will roll back the transaction, and <strong>discard all data written to the database earlier within that transaction</strong>.</p>
     </li>
   );
 };

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -122,17 +122,23 @@ function fullTransactionIdMinusEpoch(
   return Number(BigInt(value) - (BigInt(epoch) << BigInt(32)));
 }
 
+function formatFullTransactionID(value: number): string {
+  const epoch = epochFromFullTransactionId(value);
+  const xid = xidFromFullTransactionId(value) as number;
+
+  return `${epoch}:${xid}`;
+}
+
 const XminHeldBackInfo: React.FunctionComponent<{
   type: string;
   info: HeldBackInfoType;
 }> = ({ type, info }) => {
-  const epoch = epochFromFullTransactionId(info["xmin"]);
-  const xid = xidFromFullTransactionId(info["xmin"]) as number;
+  const fullTxid = formatFullTransactionID(info["xmin"]);
 
   return (
     <>
       A {type} is holding back the xmin horizon at{" "}
-      <code>{`${epoch}:${xid}`}</code> (assigned at {new Date(info["assigned_at"] * 1000).toISOString()})
+      <code>{`${fullTxid}`}</code> (assigned at {new Date(info["assigned_at"] * 1000).toISOString()})
     </>
   );
 }

--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -98,9 +98,48 @@ const XminHorizonGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
   );
 };
 
+type HeldBackInfoType = {
+  xmin: number;
+  assigned_at: number;
+}
+
+function epochFromFullTransactionId(value: number): number {
+  return Number(BigInt(value) >> BigInt(32));
+}
+
+function xidFromFullTransactionId(value: number | null): number | null {
+  if (value == null) {
+    return null;
+  }
+  const epoch = epochFromFullTransactionId(value);
+  return fullTransactionIdMinusEpoch(value, epoch);
+}
+
+function fullTransactionIdMinusEpoch(
+  value: number,
+  epoch: number,
+): number {
+  return Number(BigInt(value) - (BigInt(epoch) << BigInt(32)));
+}
+
+const XminHeldBackInfo: React.FunctionComponent<{
+  type: string;
+  info: HeldBackInfoType;
+}> = ({ type, info }) => {
+  const epoch = epochFromFullTransactionId(info["xmin"]);
+  const xid = xidFromFullTransactionId(info["xmin"]) as number;
+
+  return (
+    <>
+      A {type} is holding back the xmin horizon at{" "}
+      <code>{`${epoch}:${xid}`}</code> (assigned at {new Date(info["assigned_at"] * 1000).toISOString()})
+    </>
+  );
+}
+
 const GuidanceByBackend: React.FunctionComponent<{
   inApp: boolean;
-  heldBackInfo: number | null;
+  heldBackInfo: HeldBackInfoType | null;
 }> = ({ inApp, heldBackInfo }) => {
   if (inApp && !heldBackInfo) {
     return null;
@@ -119,8 +158,7 @@ const GuidanceByBackend: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          A long running transaction is holding back the xmin horizon at{" "}
-          <code>{heldBackInfo["xmin"]}</code>.
+          <XminHeldBackInfo type="long-running transaction" info={heldBackInfo} />.
         </p>
       )}
       <p>
@@ -145,7 +183,7 @@ const GuidanceByBackend: React.FunctionComponent<{
 
 const GuidanceByReplicationSlot: React.FunctionComponent<{
   inApp: boolean;
-  heldBackInfo: number | null;
+  heldBackInfo: HeldBackInfoType | null;
   serverReplicationUrl: string;
 }> = ({ inApp, heldBackInfo, serverReplicationUrl }) => {
   if (inApp && !heldBackInfo) {
@@ -169,8 +207,7 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          A replication slot is holding back the xmin horizon at{" "}
-          <code>{heldBackInfo["xmin"]}</code>.
+          <XminHeldBackInfo type="replication slot" info={heldBackInfo} />.
         </p>
       )}
       <p>
@@ -190,7 +227,7 @@ const GuidanceByReplicationSlot: React.FunctionComponent<{
 
 const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
   inApp: boolean;
-  heldBackInfo: number | null;
+  heldBackInfo: HeldBackInfoType | null;
   serverReplicationUrl: string;
 }> = ({ inApp, heldBackInfo, serverReplicationUrl }) => {
   if (inApp && !heldBackInfo) {
@@ -215,9 +252,8 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          A replication slot is holding back the xmin horizon at{" "}
-          <code>{heldBackInfo["xmin"]}</code>, specifically with system
-          catalogs.
+          <XminHeldBackInfo type="replication slot" info={heldBackInfo} />,
+          specifically with system catalogs.
         </p>
       )}
       <p>
@@ -240,7 +276,7 @@ const GuidanceByReplicationSlotCatalog: React.FunctionComponent<{
 
 const GuidanceByStandby: React.FunctionComponent<{
   inApp: boolean;
-  heldBackInfo: number | null;
+  heldBackInfo: HeldBackInfoType | null;
 }> = ({ inApp, heldBackInfo }) => {
   if (inApp && !heldBackInfo) {
     return null;
@@ -260,8 +296,7 @@ const GuidanceByStandby: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          A long running query on a standby is holding back the xmin horizon at{" "}
-          <code>{heldBackInfo["xmin"]}</code>.
+          <XminHeldBackInfo type="long running query on a standby" info={heldBackInfo} />.
         </p>
       )}
       <p>
@@ -294,7 +329,7 @@ const GuidanceByStandby: React.FunctionComponent<{
 
 const GuidanceByPreparedXact: React.FunctionComponent<{
   inApp: boolean;
-  heldBackInfo: number | null;
+  heldBackInfo: HeldBackInfoType | null;
 }> = ({ inApp, heldBackInfo }) => {
   if (inApp && !heldBackInfo) {
     return null;
@@ -318,8 +353,7 @@ const GuidanceByPreparedXact: React.FunctionComponent<{
       </h6>
       {heldBackInfo && (
         <p>
-          A prepared transaction is holding back the xmin horizon at{" "}
-          <code>{heldBackInfo["xmin"]}</code>.
+          <XminHeldBackInfo type="prepared transaction" info={heldBackInfo} />.
         </p>
       )}
       <p>


### PR DESCRIPTION
```
Xmin horizon check: Show TXID with separate epoch, and assigned at time

Since the statistics views in Postgres utilize the 32-bit version of
transaction IDs, but we track 64-bit internally, it can be confusing
to show the raw 64-bit value (since you can't visually compare it to
queries you run on the database). To improve, instead format it with
a separate epoch, separated by a colon, like we do for freezing stats.

Additionally show the specific assigned at timestamp inline, to help
identify the problem origin better, e.g. to use for comparison with
xact_start in pg_stat_activity, when xmin horizon is held back by a
long-running transaction.

In passing introduce a component to handle xmin information consistently,
and fix typing for "heldBackInfo", which was incorrectly marked as a raw
number (its an object).
```
```
Xmin horizon check: Clarify that pg_terminate_backend is needed sometimes

To stop a long-running transaction that's idle, one needs to terminate
the connection, not just cancel (the non-existent) active query.

Additionally add a stronger disclaimer about the possible impact of such
an action.
```

Before:

<img width="656" alt="Screenshot 2023-10-25 at 12 04 12 AM" src="https://github.com/pganalyze/pganalyze-docs/assets/7227/e8b4500c-d105-43eb-9ac3-eef2250ebb29">

After:

<img width="665" alt="Screenshot 2023-10-25 at 12 05 33 AM" src="https://github.com/pganalyze/pganalyze-docs/assets/7227/20d7bbf6-1699-4382-aa33-8b8c27e3cee2">
