### PR TITLE
Add description for DB_ALL_NAMES env var for collector settings

### DIFF
--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -174,6 +174,14 @@ helper functions are expected to be defined, and the one we connect to for serve
       <td>[none]</td>
       <td>Alternative to above, using actual contents of the key</td>
     </tr>
+    <tr>
+      <td><code>DB_ALL_NAMES</code></td>
+      <td>false</td>
+      <td>Alternative to setting <code>*</code> at the last entry of db_name (<code>DB_NAME</code>),
+      monitoring all databases on server. Can be only set using an environment variable.<br />
+      This is helpful when db_url (<code>DB_URL</code>) is used to specify a monitoring server (db_name is unused)
+      and you want to monitor all databases on that server.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -177,8 +177,8 @@ helper functions are expected to be defined, and the one we connect to for serve
     <tr>
       <td><code>DB_ALL_NAMES</code></td>
       <td>false</td>
-      <td>Alternative to setting <code>*</code> at the last entry of db_name (<code>DB_NAME</code>),
-      monitoring all databases on server. Can be only set using an environment variable.<br />
+      <td>Alternative to setting <code>*</code> as the last entry of db_name (<code>DB_NAME</code>) to
+      monitor all databases on the server. Can only be set using an environment variable.<br />
       This is helpful when db_url (<code>DB_URL</code>) is used to specify a monitoring server (db_name is unused)
       and you want to monitor all databases on that server.</td>
     </tr>


### PR DESCRIPTION
Just realized that `DB_ALL_NAMES` is not documented, so adding it. It's introduced back in 2017:

https://github.com/pganalyze/collector/blob/b366c7fa7c152894758159602cb599fa2412760a/CHANGELOG.md?plain=1#L1363
