### PR TITLE
Add CRUNCHY_BRIDGE_API_KEY for the doc

### DIFF
--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -478,6 +478,36 @@ Only relevant if you are running your database in GCP using Google Cloud SQL or 
   </tbody>
 </table>
 
+## Crunchy Bridge settings
+
+Only relevant if you are running your database in Crunchy Bridge.
+
+<table>
+  <thead>
+    <tr>
+      <th>Setting</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>crunchy_bridge_api_key (<code>CRUNCHY_BRIDGE_API_KEY</code>)</td>
+      <td>n/a, required for accurate Storage Space information</td>
+      <td>
+        The API key of Crunchy Bridge. When specified, the collector uses the
+        Crunchy Bridge API to obtain accurate Storage Space information, as well
+        as cluster information.
+      </td>
+    </tr>
+    <tr>
+      <td>crunchy_bridge_cluster_id (<code>CRUNCHY_BRIDGE_CLUSTER_ID</code>)</td>
+      <td>auto-detected from hostname</td>
+      <td>ID of your cluster; may need to be set manually when using IP addresses or custom DNS records</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Self-managed servers
 
 If running on your own infrastructure, a platform other than the cloud providers listed above, or in

--- a/install/crunchy_bridge/01_deploy_the_collector.mdx
+++ b/install/crunchy_bridge/01_deploy_the_collector.mdx
@@ -11,7 +11,7 @@ import { MonitoringUserColumnStats, MonitoringUserLogRead } from "../../componen
 export const CollectorStartCommand = ({ apiKey, cmd, logExplain }) => {
   return (
     <CodeBlock>
-      {`SELECT run_container('` + (cmd ? '' : '-d ') + `-t -e DB_URL="REPLACE_ME" -e PGA_API_KEY="` + (apiKey ? apiKey : 'API_KEY') + '"' + (logExplain ? ' -e PGA_ENABLE_LOG_EXPLAIN=true' : '') + ` -e DB_ALL_NAMES=1 quay.io/pganalyze/collector:stable` + (cmd ? ` ${cmd}` : '') + `');`}
+      {`SELECT run_container('` + (cmd ? '' : '-d ') + `-t -e DB_URL="REPLACE_ME" -e PGA_API_KEY="` + (apiKey ? apiKey : 'API_KEY') + '"' + (logExplain ? ' -e PGA_ENABLE_LOG_EXPLAIN=true' : '') + ` -e CRUNCHY_BRIDGE_API_KEY="REPLACE_ME" -e DB_ALL_NAMES=1 quay.io/pganalyze/collector:stable` + (cmd ? ` ${cmd}` : '') + `');`}
     </CodeBlock>
   );
 };
@@ -45,16 +45,23 @@ If you have not yet enabled Postgres Container Apps, connect to your Crunchy Bri
 CREATE EXTENSION IF NOT EXISTS pgpodman;
 ```
 
+## Create Crunchy Bridge API key
+
+Providing the Crunchy Bridge API key to the collector will allow the collector to obtain accurate Storage Space information, as well as cluster information.
+It is recommended to create a new API key for the collector and passing it as an environment value.
+See the [Crunchy Bridge documentation](https://docs.crunchybridge.com/api-concepts/getting-started) for how to create API keys.
+
 ## Run collector test
 
-Run the following command to verify the configuration. For the `DB_URL` specify the application user credentials.
+Run the following command to verify the configuration. For the `DB_URL`, specify the application user credentials.
+For the `CRUNCHY_BRIDGE_API_KEY`, specify the API key created above.
 
 <CollectorStartCommand apiKey={props.apiKey} cmd="test" />
 
 This should return output like this:
 
 ```
-                                run_container                                   
+                                run_container
 --------------------------------------------------------------------------------
  I Running collector test with pganalyze-collector X.XX.X
  I [default] Testing statistics collection...


### PR DESCRIPTION
⚠️ Blocked by https://github.com/pganalyze/collector/pull/483

Starting from the collector 0.52.3, it supports `CRUNCHY_BRIDGE_API_KEY`. Update docs to mention what it is and how to specify it.