### PR TITLE
Update OpenTelemetry doc to include the pganalyze tracestate

### DIFF
--- a/opentelemetry/index.mdx
+++ b/opentelemetry/index.mdx
@@ -67,6 +67,9 @@ data.
     * This issue will typically occur with Amazon RDS and Amazon Aurora, which
       currently do not allow changing the timestamp precision of the
       `log_line_prefix` (it's always set to`%t:%r:%u@%d:[%p]:t`)
+    * You can workaround this by passing the query start time with the pganalyze
+      tracestate. See [Add pganalyze tracestate](/docs/opentelemetry/traceparent#add-pganalyze-tracestate)
+      for examples of how to add it
 
 ## Troubleshooting
 

--- a/opentelemetry/traceparent.mdx
+++ b/opentelemetry/traceparent.mdx
@@ -165,7 +165,7 @@ When performing manual instrumentation, these instrumentations won't be enabled
 automatically. To have better tracing spans around the queries, it is
 recommended to enable instrumentations related to ORMs and/or database drivers.
 
-## Add pganalyze tracestate
+## Add pganalyze tracestate (optional)
 
 When the Postgres database has limited precision in its `log_line_prefix`
 timestamp, timing data of spans exported by pganalyze may not line up with other
@@ -178,7 +178,7 @@ To workaround this, you can use the `pganalyze` tracestate and pass the query
 start time with it. You can learn more about the tracestate in OpenTelemetry
 document [TraceState](https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate) section.
 
-The pganalyze tracestate should use the `pganalyze` key, and the value being a
+The pganalyze tracestate should use the `pganalyze` key, with the value being a
 semicolon separated list of key-value pairs such as:
 
 ```
@@ -195,7 +195,7 @@ time.
 
 ### Rails 7+
 
-Assuming that you already have the traceparent setup with Rails 7+, you can
+Assuming that you already have the traceparent set up with Rails 7+, you can
 append the tracestate tag like the following:
 
 ```ruby
@@ -231,7 +231,7 @@ config.active_record.query_log_tags = [
 
 ### Marginalia
 
-Assuming that you already have the traceparent setup with Marginalia, you can
+Assuming that you already have the traceparent set up with Marginalia, you can
 append the tracestate tag like the following:
 
 

--- a/opentelemetry/traceparent.mdx
+++ b/opentelemetry/traceparent.mdx
@@ -164,3 +164,103 @@ Psycopg2Instrumentor().instrument(enable_commenter=True, commenter_options={})
 When performing manual instrumentation, these instrumentations won't be enabled
 automatically. To have better tracing spans around the queries, it is
 recommended to enable instrumentations related to ORMs and/or database drivers.
+
+## Add pganalyze tracestate
+
+When the Postgres database has limited precision in its `log_line_prefix`
+timestamp, timing data of spans exported by pganalyze may not line up with other
+spans exported by the application.
+This issue will typically occur with Amazon RDS and Amazon Aurora, which
+currently do not allow changing the timestamp precision of the
+`log_line_prefix` (it's always set to`%t:%r:%u@%d:[%p]:t`).
+
+To workaround this, you can use the `pganalyze` tracestate and pass the query
+start time with it. You can learn more about the tracestate in OpenTelemetry
+document [TraceState](https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate) section.
+
+The pganalyze tracestate should use the `pganalyze` key, and the value being a
+semicolon separated list of key-value pairs such as:
+
+```
+pganalyze=key1:value1;key2:value2
+```
+
+Currently, `t` is the only supported key-value pair to specify the query start
+time.
+
+| key | value |
+|-----|-------|
+| t   | The start time of query. Unix time in seconds, with decimals to specify precision down to nano seconds |
+
+
+### Rails 7+
+
+Assuming that you already have the traceparent setup with Rails 7+, you can
+append the tracestate tag like the following:
+
+```ruby
+config.active_record.query_log_tags = [
+  :application,
+  :controller,
+  :action,
+  :job,
+  {
+    traceparent: -> () {
+      current_span = ::OpenTelemetry::Trace.current_span
+      return if current_span == ::OpenTelemetry::Trace::Span::INVALID
+
+      span_context = current_span.context
+      trace_flag   = span_context.trace_flags.sampled? ? '01' : '00'
+      format(
+        '00-%<trace_id>s-%<span_id>s-%<trace_flags>.2d',
+        trace_id: span_context.hex_trace_id,
+        span_id: span_context.hex_span_id,
+        trace_flags: trace_flag
+      )
+    },
+    tracestate: -> () {
+      current_span = ::OpenTelemetry::Trace.current_span
+      return if current_span == ::OpenTelemetry::Trace::Span::INVALID
+
+      tracestate = current_span.context.tracestate.set_value('pganalyze', "t:#{Time.now.utc.to_f}")
+      tracestate.to_s
+    }
+  }
+]
+```
+
+### Marginalia
+
+Assuming that you already have the traceparent setup with Marginalia, you can
+append the tracestate tag like the following:
+
+
+```ruby
+module Marginalia
+  module Comment
+    def self.traceparent
+      current_span = ::OpenTelemetry::Trace.current_span
+      return if current_span == ::OpenTelemetry::Trace::Span::INVALID
+
+      span_context = current_span.context
+      trace_flag   = span_context.trace_flags.sampled? ? '01' : '00'
+      format(
+        '00-%<trace_id>s-%<span_id>s-%<trace_flags>.2d',
+        trace_id: span_context.hex_trace_id,
+        span_id: span_context.hex_span_id,
+        trace_flags: trace_flag
+      )
+    end
+
+    def self.tracestate
+      current_span = ::OpenTelemetry::Trace.current_span
+      return if current_span == ::OpenTelemetry::Trace::Span::INVALID
+
+      tracestate = current_span.context.tracestate.set_value('pganalyze', "t:#{Time.now.utc.to_f}")
+      tracestate.to_s
+    end
+  end
+end
+
+Marginalia::Comment.components = [:application, :controller, :action, :job, :traceparent, :tracestate]
+```


### PR DESCRIPTION
From the collector v0.52.3, we can pass the pganalyze `tracestate`. This PR adds the document for it.