### PR TITLE
Use image tag instead of markdown to support showing image in app

### DIFF
--- a/explain/setup/azure_database/_02_actually_enable.mdx
+++ b/explain/setup/azure_database/_02_actually_enable.mdx
@@ -1,3 +1,10 @@
+import imgAzureServerParamsAutoExplain from './azure_server_params_auto_explain.png'
+import imgAzureSaveServerParameter from './azure_save_server_parameter.png'
+
+export const ImgAzureServerParamsAutoExplain = () => <img alt="Server parameters: auto_explain" src={imgAzureServerParamsAutoExplain} />
+
+export const ImgAzureSaveServerParameter = () => <img alt="Save server parameters" src={imgAzureSaveServerParameter} />
+
 export const SPLRecommendation = ({recommendation}) => {
    if (recommendation.current == null) {
       return (
@@ -21,12 +28,12 @@ export const SPLRecommendation = ({recommendation}) => {
 In your [Azure Portal](https://portal.azure.com/), find your DB instance, and open the Server Parameters
 page. Filter parameters by `shared_preload_libraries`, and enable `AUTO_EXPLAIN`, making sure to save settings.
 
-![](azure_server_params_auto_explain.png)
+<ImgAzureServerParamsAutoExplain />
 
 Saving will show the following prompt. You can choose to either restart now or restart later.
 Either way, you will need to restart before proceeding the next step.
 
-![](azure_save_server_parameter.png)
+<ImgAzureSaveServerParameter />
 
 After the reboot completes, verify that `shared_preload_libraries` now includes `auto_explain`
 and that the setting change does not require a restart (`pending_restart` should be `f`):


### PR DESCRIPTION
This markdown is used to render the content in app too, so using something like `![](azure_server_params_auto_explain.png)` doesn't work. You can see that it's currently not working in the following, for example:
https://staging.pganalyze.com/servers/kfip7efqrvgydlp2h7grlwvkiq/setup/explain/azure_database/02_enable_auto_explain

To fix this, use image tag instead.