### PR TITLE
Index Advisor: Missing Indexes issue docs

### DIFF
--- a/components/CheckDocumentation/index.tsx
+++ b/components/CheckDocumentation/index.tsx
@@ -7,7 +7,7 @@ import ActiveQuery from "./connections/ActiveQuery";
 import IdleTransaction from "./connections/IdleTransaction";
 import BlockingQuery from "./connections/BlockingQuery";
 import MissingIndex from "./index_advisor/MissingIndex";
-import IndexInsights from "./index_advisor/IndexInsights";
+import IndexingEngine from "./index_advisor/IndexingEngine";
 import IndexInvalid from "./schema/IndexInvalid";
 import IndexUnused from "./schema/IndexUnused";
 import EnableFeatures from "./settings/EnableFeatures";
@@ -37,7 +37,7 @@ const Docs: {
   },
   index_advisor: {
     missing_index: MissingIndex,
-    index_insights: IndexInsights,
+    indexing_engine: IndexingEngine,
   },
   schema: {
     index_invalid: IndexInvalid,

--- a/components/CheckDocumentation/index.tsx
+++ b/components/CheckDocumentation/index.tsx
@@ -7,6 +7,7 @@ import ActiveQuery from "./connections/ActiveQuery";
 import IdleTransaction from "./connections/IdleTransaction";
 import BlockingQuery from "./connections/BlockingQuery";
 import MissingIndex from "./index_advisor/MissingIndex";
+import IndexInsights from "./index_advisor/IndexInsights";
 import IndexInvalid from "./schema/IndexInvalid";
 import IndexUnused from "./schema/IndexUnused";
 import EnableFeatures from "./settings/EnableFeatures";
@@ -36,6 +37,7 @@ const Docs: {
   },
   index_advisor: {
     missing_index: MissingIndex,
+    index_insights: IndexInsights,
   },
   schema: {
     index_invalid: IndexInvalid,

--- a/components/CheckDocumentation/index_advisor/IndexInsights.tsx
+++ b/components/CheckDocumentation/index_advisor/IndexInsights.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import {
+  CheckDocs,
+  CheckGuidanceProps,
+  CheckTriggerProps,
+} from "../../../util/checks";
+
+const IndexInsightsTrigger: React.FunctionComponent<CheckTriggerProps> = () => {
+  return (
+    <p>
+      Detects when a table might be missing indexes based on the query workload
+      over the last seven days and creates an issue with severity "info".
+      Resolves once the recommended indexes have been created, or the workload has
+      changed such that the indexes are no longer relevant.
+    </p>
+  );
+};
+
+const IndexInsightsGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
+  issue,
+}) => {
+  if (issue) {
+    // The Index Insights check has dynamic guidance, so this component is not used in-app (aka when `issue` is present)
+    return null;
+  }
+  return (
+    <p>
+      You can learn about Index Advisor and index insights in{" "}
+      <a href="https://pganalyze.com/docs/index-advisor/reason-about-insights">
+        the Index Advisor documentation
+      </a>
+      .
+    </p>
+  );
+};
+
+const documentation: CheckDocs = {
+  description:
+    "Detects when a table might be missing indexes based on the query workload.",
+  Trigger: IndexInsightsTrigger,
+  Guidance: IndexInsightsGuidance,
+};
+
+export default documentation;

--- a/components/CheckDocumentation/index_advisor/IndexingEngine.tsx
+++ b/components/CheckDocumentation/index_advisor/IndexingEngine.tsx
@@ -6,7 +6,7 @@ import {
   CheckTriggerProps,
 } from "../../../util/checks";
 
-const IndexInsightsTrigger: React.FunctionComponent<CheckTriggerProps> = () => {
+const IndexingEngineTrigger: React.FunctionComponent<CheckTriggerProps> = () => {
   return (
     <p>
       Detects when a table might be missing indexes based on the query workload
@@ -17,7 +17,7 @@ const IndexInsightsTrigger: React.FunctionComponent<CheckTriggerProps> = () => {
   );
 };
 
-const IndexInsightsGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
+const IndexingEngineGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
   issue,
 }) => {
   if (issue) {
@@ -38,8 +38,8 @@ const IndexInsightsGuidance: React.FunctionComponent<CheckGuidanceProps> = ({
 const documentation: CheckDocs = {
   description:
     "Detects when a table might be missing indexes based on the query workload.",
-  Trigger: IndexInsightsTrigger,
-  Guidance: IndexInsightsGuidance,
+  Trigger: IndexingEngineTrigger,
+  Guidance: IndexingEngineGuidance,
 };
 
 export default documentation;

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -9,7 +9,7 @@ export const CHECK_TITLES = {
   },
   index_advisor: {
     missing_index: "Missing Index",
-    index_insights: "Missing Indexes",
+    indexing_engine: "Missing Indexes",
   },
   schema: {
     index_invalid: "Invalid Indexes",
@@ -49,7 +49,7 @@ export const CHECK_SEVERITIES = {
   },
   index_advisor: {
     missing_index: ['info'],
-    index_insights: ['info'],
+    indexing_engine: ['info'],
   },
   schema: {
     index_invalid: ['info'],
@@ -113,7 +113,7 @@ export const CHECK_FREQUENCY = {
   },
   index_advisor: {
     missing_index: CHECK_FREQUENCY_DAILY,
-    index_insights: CHECK_FREQUENCY_DAILY,
+    indexing_engine: CHECK_FREQUENCY_DAILY,
   },
   schema: {
     index_invalid: CHECK_FREQUENCY_30MIN,
@@ -186,7 +186,7 @@ export const DEFAULT_CHECK_CONFIGS: DefaultCheckConfigs = {
     missing_index: {
       enabled: true
     },
-    index_insights: {
+    indexing_engine: {
       enabled: true
     }
   },

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -9,6 +9,7 @@ export const CHECK_TITLES = {
   },
   index_advisor: {
     missing_index: "Missing Index",
+    index_insights: "Index Insights",
   },
   schema: {
     index_invalid: "Invalid Indexes",
@@ -48,6 +49,7 @@ export const CHECK_SEVERITIES = {
   },
   index_advisor: {
     missing_index: ['info'],
+    index_insights: ['info'],
   },
   schema: {
     index_invalid: ['info'],
@@ -111,6 +113,7 @@ export const CHECK_FREQUENCY = {
   },
   index_advisor: {
     missing_index: CHECK_FREQUENCY_DAILY,
+    index_insights: CHECK_FREQUENCY_DAILY,
   },
   schema: {
     index_invalid: CHECK_FREQUENCY_30MIN,
@@ -181,6 +184,9 @@ export const DEFAULT_CHECK_CONFIGS: DefaultCheckConfigs = {
   },
   index_advisor: {
     missing_index: {
+      enabled: true
+    },
+    index_insights: {
       enabled: true
     }
   },

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -9,7 +9,7 @@ export const CHECK_TITLES = {
   },
   index_advisor: {
     missing_index: "Missing Index",
-    index_insights: "Index Insights",
+    index_insights: "Missing Indexes",
   },
   schema: {
     index_invalid: "Invalid Indexes",


### PR DESCRIPTION
Add a Missing Indexes issue. This is like the existing Missing Index
issue, but it looks at all index recommendations on a single table
together, rather than recommending individual indexes in separate
issues.
