### PR TITLE
Docker install steps: Add missing instruction for public docs

### DIFF
--- a/install/self_managed/04_configure_the_collector_docker.mdx
+++ b/install/self_managed/04_configure_the_collector_docker.mdx
@@ -48,10 +48,20 @@ Fill in the values step-by-step:
 
 ## Test snapshot
 
-Then run the following:
+Then run the following to test the configuration:
 
 ```
 docker run --env-file pganalyze_collector.env quay.io/pganalyze/collector:stable test
 ```
+
+<PublicOnly>
+
+After a successful test you can now start the collector in the background:
+
+```
+docker run -d --name pganalyze-collector --env-file pganalyze_collector.env quay.io/pganalyze/collector:stable
+```
+
+</PublicOnly>
 
 <PublicLastStepLogInsightsLink />


### PR DESCRIPTION
The in-app instructions have a conditional for Docker-based install in the `PublicLastStepLogInsightsLink` component that explains that one needs to start the container in the background after the initial test. This was missing from the public docs, causing a confusing install experience.