### PR TITLE
Docs for get_relation_stats_ext helper func

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -17,6 +17,7 @@ const MonitoringUserSetupInstructions: React.FunctionComponent<Props> = ({
     <>
       <MonitoringUserBase password={password} noPgMonitor={noPgMonitor} />
       <MonitoringUserColumnStats username="pganalyze" adminUsername={adminUsername} />
+      <MonitoringUserExtStats username="pganalyze" adminUsername={adminUsername} />
     </>
   );
 };

--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -83,7 +83,7 @@ $$
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
       </CodeBlock>
       <p>
-        <strong>Note:</strong> We never collect actual table data through this method (from the <code>pg_stats_ext</code> view, we are not collecting things like <code>most_common_vals</code> as you can see in the function definition), but we do collect statistics about the distribution of values in your tables.
+        <strong>Note:</strong> We never collect actual table data through this method (we omit fetching fields like <code>most_common_vals</code> from the <code>pg_stats_ext</code> view, as you can see in the function definition), but we do collect statistics about the distribution of values in your tables.
         You can skip creating the <code>get_relation_stats_ext</code> helper function if the database
         contains highly sensitive information and statistics about it should not be collected.
         This will impact the accuracy of Index Advisor recommendations.

--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -45,8 +45,47 @@ $$
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
       </CodeBlock>
       <p>
-        <strong>Note:</strong> We never collect actual table data through this method (see the <code>NULL</code> values in the function), but we do collect statistics about the distribution of values in your tables. You can skip creating the <code>get_column_stats</code> helper function if the database
-        contains highly sensitive information and statistics about it should not be collected. This will impact the accuracy of Index Advisor recommendations.
+        <strong>Note:</strong> We never collect actual table data through this method (see the <code>NULL</code> values in the function), but we do collect statistics about the distribution of values in your tables.
+        You can skip creating the <code>get_column_stats</code> helper function if the database
+        contains highly sensitive information and statistics about it should not be collected.
+        This will impact the accuracy of Index Advisor recommendations.
+      </p>
+    </>
+  );
+};
+
+export const MonitoringUserExtStats: React.FunctionComponent<{ username: string, adminUsername: string }> = ({
+  username,
+  adminUsername
+}) => {
+  const adminUserStr = !!adminUsername ? <strong>{adminUsername}</strong> : 'a superuser (or equivalent)'
+  const CodeBlock = useCodeBlock();
+  return (
+    <>
+      <p>
+        Then, connect to each database that you plan to monitor on this server as {adminUserStr} and
+        run the following to enable the collection of additional extended statistics:
+      </p>
+      <CodeBlock>
+        {`CREATE SCHEMA IF NOT EXISTS pganalyze;
+GRANT USAGE ON SCHEMA pganalyze TO ${username};
+CREATE OR REPLACE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
+  statistics_schemaname text, statistics_name text,
+  inherited boolean, n_distinct pg_ndistinct, dependencies pg_dependencies,
+  most_common_val_nulls boolean[], most_common_freqs float8[], most_common_base_freqs float8[]
+) AS
+$$
+  /* pganalyze-collector */ SELECT statistics_schemaname, statistics_name,
+  (row_to_json(se.*)::jsonb ->> 'inherited')::boolean AS inherited, n_distinct, dependencies,
+  most_common_val_nulls, most_common_freqs, most_common_base_freqs
+  FROM pg_catalog.pg_stats_ext se;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
+      </CodeBlock>
+      <p>
+        <strong>Note:</strong> We never collect actual table data through this method (from the <code>pg_stats_ext</code> view, we are not collecting things like <code>most_common_vals</code> as you can see in the function definition), but we do collect statistics about the distribution of values in your tables.
+        You can skip creating the <code>get_relation_stats_ext</code> helper function if the database
+        contains highly sensitive information and statistics about it should not be collected.
+        This will impact the accuracy of Index Advisor recommendations.
       </p>
     </>
   );

--- a/directory.json
+++ b/directory.json
@@ -760,6 +760,10 @@
       "title": "Resolving the \"Limited access to table column statistics\" warning",
       "path": "/docs/install/troubleshooting/column_stats_helper"
     },
+    "install/troubleshooting/ext_stats_helper": {
+      "title": "Resolving the \"missing extended stats monitoring helper functions\" warning",
+      "path": "/docs/install/troubleshooting/ext_stats_helper"
+    },
     "install/troubleshooting/pg_stat_statements": {
       "title": "Resolving the 'permission denied to create extension \"pg_stat_statements\"' error",
       "path": "/docs/install/troubleshooting/pg_stat_statements"

--- a/index-advisor/getting-started.mdx
+++ b/index-advisor/getting-started.mdx
@@ -65,6 +65,20 @@ for warnings in the collector test output (`pganalyze-collector --test
 --verbose`).
 
 
+## Set up the extended stats helper for better recommendations
+
+Extended statistics are used by pganalyze to improve Index Advisor
+recommendations. If you are using the extended statistics (created via
+`CREATE STATISTICS`), for best results, make sure you are running collector
+0.53.0 or later, and [set up the get_relation_stats_ext helper
+function](/docs/install/troubleshooting/ext_stats_helper).
+
+You can check which collector version you are running on the Settings page for
+your server, and can check if the column stats helpers are installed by looking
+for warnings in the collector test output (`pganalyze-collector --test
+--verbose`).
+
+
 ## How to navigate the insights overview
 
 ![Overview of missing index insights](/missing-index-list.png)

--- a/index-advisor/getting-started.mdx
+++ b/index-advisor/getting-started.mdx
@@ -67,16 +67,14 @@ for warnings in the collector test output (`pganalyze-collector --test
 
 ## Set up the extended stats helper for better recommendations
 
-Extended statistics are used by pganalyze to improve Index Advisor
-recommendations. If you are using the extended statistics (created via
-`CREATE STATISTICS`), for best results, make sure you are running collector
+[Extended statistics](https://www.postgresql.org/docs/current/sql-createstatistics.html)
+are used by pganalyze to improve Index Advisor recommendations. If you are using
+the extended statistics, for best results, make sure you are running collector
 0.53.0 or later, and [set up the get_relation_stats_ext helper
 function](/docs/install/troubleshooting/ext_stats_helper).
 
 You can check which collector version you are running on the Settings page for
-your server, and can check if the column stats helpers are installed by looking
-for warnings in the collector test output (`pganalyze-collector --test
---verbose`).
+your server.
 
 
 ## How to navigate the insights overview

--- a/install/crunchy_bridge/01_deploy_the_collector.mdx
+++ b/install/crunchy_bridge/01_deploy_the_collector.mdx
@@ -6,7 +6,7 @@ backlink_title: 'Installation Guide'
 ---
 
 import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_link.mdx';
-import { MonitoringUserColumnStats, MonitoringUserLogRead } from "../../components/MonitoringUserSetupInstructions";
+import { MonitoringUserColumnStats, MonitoringUserLogRead, MonitoringUserExtStats } from "../../components/MonitoringUserSetupInstructions";
 
 export const CollectorStartCommand = ({ apiKey, cmd, logExplain }) => {
   return (
@@ -34,6 +34,8 @@ Additionally, run the following to allow the application user to read the Postgr
 <MonitoringUserLogRead username="application" />
 
 <MonitoringUserColumnStats username="application" />
+
+<MonitoringUserExtStats username="application" />
 
 In later steps you can now specify the application user credentials as the `DB_URL`.
 

--- a/install/troubleshooting.mdx
+++ b/install/troubleshooting.mdx
@@ -10,3 +10,4 @@ This section provides helpful information about troubleshooting your pganalyze i
  * [Collector times out](/docs/install/troubleshooting/collector_times_out)
  * [Amazon RDS: Resolving the "pg\_stat\_statements must be loaded via shared\_preload\_libraries" error](/docs/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries)
  * [Resolving the "Limited access to table column statistics" warning](/docs/install/troubleshooting/column_stats_helper)
+ * [Resolving the "missing extended stats monitoring helper functions" warning](/docs/install/troubleshooting/ext_stats_helper)

--- a/install/troubleshooting/ext_stats_helper.mdx
+++ b/install/troubleshooting/ext_stats_helper.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Resolving the "missing extended stats monitoring helper functions" warning'
+backlink_href: /docs/install/troubleshooting
+backlink_title: 'Installation Troubleshooting'
+---
+
+import { MonitoringUserExtStats } from "../../components/MonitoringUserSetupInstructions";
+
+You may see the following warning in the pganalyze app:
+
+```
+Your database appears to be missing extended stats monitoring helper functions,
+so the data of extended statistics are not available. Please review the relevant
+troubleshooting documentation.
+```
+
+This warning indicates that extended statistics for the specific database are
+not being reported by the collector. Extended statistics are used by pganalyze
+to improve Index Advisor recommendations. Index Advisor will still work without
+the helper functions, but index recommendations may be less accurate.
+
+To resolve this, first, make sure you are running at least collector version
+0.53.0 (and ideally the latest version). You can see which version you are
+currently running by checking the Debug Info panel on the Server Settings tab of
+the Settings page for your server. Then, find the name for the database role
+that's configured as the monitoring user in your collector installation (we'll
+assume "pganalyze" here).
+
+<MonitoringUserExtStats username="pganalyze" />
+
+Note that unlike other pganalyze helper functions, this function must be
+installed in *every database* that you intend to monitor separately.
+
+After creating the helper function in all monitored databases, re-run the
+collector test to confirm the warning is no longer displayed.

--- a/install/troubleshooting/toc.yml
+++ b/install/troubleshooting/toc.yml
@@ -6,6 +6,8 @@
     href: install/troubleshooting/collector_times_out
   - name: 'Resolving the "Limited access to table column statistics" warning'
     href: install/troubleshooting/column_stats_helper
+  - name: 'Resolving the "missing extended stats monitoring helper functions" warning'
+    href: install/troubleshooting/ext_stats_helper
   - name: Resolving the 'permission denied to create extension "pg_stat_statements"' error
     href: install/troubleshooting/pg_stat_statements
   - name: 'Amazon RDS: Resolving the "pg_stat_statements must be loaded via shared_preload_libraries" error'


### PR DESCRIPTION
Similar to https://pganalyze.com/docs/install/troubleshooting/column_stats_helper, create a dedicated page talking about this helper function. The warning message that mentioned in the doc will be appearing in the pganalyze app in the future.

Unlike the column stats helper, missing this helper function won't cause any warnings in the collector side, due to how we collect these data. Because of that, having this doc under install/troubleshooting is a bit inappropriate, but I can't think of any other place so I think it's okay?