### PR TITLE
Update the list of collector packages

### DIFF
--- a/collector/packages.mdx
+++ b/collector/packages.mdx
@@ -24,5 +24,5 @@ Alternately, you can install these packages manually.
 These repositories are updated by pganalyze whenever a new stable version of the
 collector is released.
 
-You can also build the collector [from source](https://github.com/pganalyze/collector): Go 1.16 and
+You can also build the collector [from source](https://github.com/pganalyze/collector): Go 1.20 and
 `make` are required. To build, just run `make`.

--- a/components/CollectorPkgInstallInstructions.tsx
+++ b/components/CollectorPkgInstallInstructions.tsx
@@ -38,12 +38,12 @@ const CollectorPkgInstallInstructions = () => {
 
 type YumProps = {
   kind: 'yum'
-  distro: 'el/8' | 'el/7' | 'fedora/35'
+  distro: 'el/9' | 'el/8' | 'el/7' | 'fedora/37' | 'fedora/36'
 }
 
 type DebProps = {
   kind: 'deb'
-  distro: "ubuntu/jammy" | "ubuntu/focal" | "ubuntu/bionic" | "debian/buster" | "debian/stretch"
+  distro: "ubuntu/jammy" | "ubuntu/focal" | "debian/bookworm" | "debian/bullseye"
 }
 
 type Props = YumProps | DebProps
@@ -54,19 +54,21 @@ const CollectorDistroInstallInstructions: React.FunctionComponent<Pick<Props, 'k
   switch (kind) {
     case 'yum':
       installOpts = [
+        [ 'el9', 'el/9', 'RHEL / Rocky / OL 9' ],
         [ 'el8', 'el/8', 'RHEL / Rocky / OL 8' ],
         [ 'el7', 'el/7', 'RHEL / CentOS 7' ],
+        [ 'al2023', 'el/9', 'Amazon Linux 2023' ],
         [ 'al2', 'el/7', 'Amazon Linux 2' ],
-        [ 'fedora35', 'fedora/35', 'Fedora 35' ],
+        [ 'fedora37', 'fedora/37', 'Fedora 37' ],
+        [ 'fedora36', 'fedora/36', 'Fedora 36' ],
       ]
       break
     case 'deb':
       installOpts = [
         ["jammy", "ubuntu/jammy", "Ubuntu 22.04"],
         ["focal", "ubuntu/focal", "Ubuntu 20.04"],
-        ["bionic", "ubuntu/bionic", "Ubuntu 18.04"],
-        ["buster", "debian/buster", "Debian 10"],
-        ["stretch","debian/stretch",  "Debian 9"],
+        ["bookworm", "debian/bookworm", "Debian 12"],
+        ["bullseye", "debian/bullseye", "Debian 11"],
       ]
       break
   }
@@ -88,7 +90,7 @@ const CollectorDistroPkgInstallInstructions: React.FunctionComponent<{
   kind: string,
   distro: string
 }> = ({ kind, distro }) => {
-  let instructions: string;
+  let instructions = "";
   const CodeBlock = useCodeBlock();
   switch (kind) {
     case 'yum':

--- a/install/self_managed/01_guided_setup.mdx
+++ b/install/self_managed/01_guided_setup.mdx
@@ -10,8 +10,8 @@ import CollectorInstallInstructions from '../../components/CollectorInstallInstr
 To begin guided setup, you'll need to install the collector, which sends statistics information
 and query activity to pganalyze.
 
-Note that guided setup is **only supported for Ubuntu 16.04 or newer or Debian 10 or newer.** If you are
-running an older version, or using a RHEL/CentOS/Amazon Linux 2 system please follow the <Link to="01_create_monitoring_user">manual setup instructions</Link>.
+Note that guided setup is **only supported for Ubuntu 20.04 or newer or Debian 11 or newer.** If you are
+running an older version, or using a RHEL/CentOS/Amazon Linux system, please follow the <Link to="01_create_monitoring_user">manual setup instructions</Link>.
 
 You will need an API key for the install. <PublicOnly>It can be found in the pganalyze Settings page for your organization.</PublicOnly><InAppOnly>It is included in the command below.</InAppOnly>
 


### PR DESCRIPTION
Just realized that this list is super outdated, so I wanted to update. Since there are so many options with yumyum now, the list is a bit too crowded but I think it's okay.

![image](https://github.com/pganalyze/pganalyze-docs/assets/911433/ade6e28a-8ce1-49f4-85f2-696feb49aa0d)

The list is coming from here:

https://github.com/pganalyze/collector/blob/main/packages/repo/sync_deb.sh
https://github.com/pganalyze/collector/blob/main/packages/repo/sync_rpm.sh
https://github.com/pganalyze/collector/blob/main/packages/test/Makefile