### PR TITLE
Update getting started overview page

### DIFF
--- a/_install_public.mdx
+++ b/_install_public.mdx
@@ -1,7 +1,7 @@
 In order to use pganalyze you need to install the [pganalyze collector](https://github.com/pganalyze/collector)
 in your environment, either on the database server directly, or a container / VM
-close to it when using managed database services. The collector sends query data
-and other statistics on a continuous basis to the pganalyze cloud service, or
-to your pganalyze Enterprise Server installation.
+that can connect to it when using managed database services. The collector sends
+query data and other statistics on a continuous basis to the pganalyze cloud
+service, or to your pganalyze Enterprise Server installation.
 
 The minimum supported PostgreSQL version is 10.

--- a/_install_public.mdx
+++ b/_install_public.mdx
@@ -1,7 +1,10 @@
 In order to use our service you need to install the [pganalyze collector](https://github.com/pganalyze/collector) on
 your Postgres database server.
 
-The collector sends normalized query data and other statistics to our service
-every 10 minutes.
+In order to use pganalyze you need to install the [pganalyze collector](https://github.com/pganalyze/collector)
+in your environment, either on the database server directly, or a container / VM
+close to it when using managed database services. The collector sends query data
+and other statistics on a continuous basis to the pganalyze cloud service, or
+to your pganalyze Enterprise Server installation.
 
 The minimum supported PostgreSQL version is 10.

--- a/_install_public.mdx
+++ b/_install_public.mdx
@@ -1,6 +1,3 @@
-In order to use our service you need to install the [pganalyze collector](https://github.com/pganalyze/collector) on
-your Postgres database server.
-
 In order to use pganalyze you need to install the [pganalyze collector](https://github.com/pganalyze/collector)
 in your environment, either on the database server directly, or a container / VM
 close to it when using managed database services. The collector sends query data

--- a/index.mdx
+++ b/index.mdx
@@ -17,7 +17,7 @@ Learn more about how pganalyze works, and how to connect it with your Postgres d
 
 ## Installation guides
 
-In order to use pganalyze you need to install the pganalyze collector in your environment, either on the database server directly, or a container / VM close to it when using managed database services. The collector sends query data and other statistics on a continuous basis — to the pganalyze cloud service, or to your pganalyze Enterprise Server installation.
+In order to use pganalyze you need to install the pganalyze collector in your environment, either on the database server directly, or a container / VM that can connect to it when using managed database services. The collector sends query data and other statistics on a continuous basis — to the pganalyze cloud service, or to your pganalyze Enterprise Server installation.
 
 To continue, select in which environment you are running your Postgres database:
 

--- a/install/01_enabling_pg_stat_statements.mdx
+++ b/install/01_enabling_pg_stat_statements.mdx
@@ -21,12 +21,10 @@ On your database server, make sure that the extensions package is installed.
 
 Debian/Ubuntu:
 
-```
-# Replace 9.X with your installed Postgres version:
-sudo apt-get install postgresql-contrib-9.X
-```
+Debian/Ubuntu includes modules like `pg_stat_statements` in the main package,
+therefore no additional install is required.
 
-RedHat/CentOS/SLES:
+RedHat/CentOS:
 
 ```
 sudo yum install postgresql-contrib
@@ -46,15 +44,10 @@ track_activity_query_size = 2048
 pg_stat_statements.track = all
 ```
 
-If you're running PostgreSQL 9.2 you may need to increase your OS shared memory
-limits when using pg\_stat\_statements.<br />
-See the Postgres [shared memory documentation](https://www.postgresql.org/docs/9.2/static/kernel-resources.html#SYSVIPC)
-for details on how to do this.
-
 ## Restart the PostgreSQL daemon
 
 ```
-sudo service postgresql restart
+sudo systemctl restart postgresql
 ```
 
 (Yeah, we don't like that reboot either, but PostgreSQL requires it for the time being)

--- a/install/01_enabling_pg_stat_statements.mdx
+++ b/install/01_enabling_pg_stat_statements.mdx
@@ -21,10 +21,12 @@ On your database server, make sure that the extensions package is installed.
 
 Debian/Ubuntu:
 
-Debian/Ubuntu includes modules like `pg_stat_statements` in the main package,
-therefore no additional install is required.
+```
+# Replace 9.X with your installed Postgres version:
+sudo apt-get install postgresql-contrib-9.X
+```
 
-RedHat/CentOS:
+RedHat/CentOS/SLES:
 
 ```
 sudo yum install postgresql-contrib
@@ -44,10 +46,15 @@ track_activity_query_size = 2048
 pg_stat_statements.track = all
 ```
 
+If you're running PostgreSQL 9.2 you may need to increase your OS shared memory
+limits when using pg\_stat\_statements.<br />
+See the Postgres [shared memory documentation](https://www.postgresql.org/docs/9.2/static/kernel-resources.html#SYSVIPC)
+for details on how to do this.
+
 ## Restart the PostgreSQL daemon
 
 ```
-sudo systemctl restart postgresql
+sudo service postgresql restart
 ```
 
 (Yeah, we don't like that reboot either, but PostgreSQL requires it for the time being)

--- a/install/azure_database/04_configure_the_collector.mdx
+++ b/install/azure_database/04_configure_the_collector.mdx
@@ -36,7 +36,7 @@ export const SelectCollectorPlatform = () => {
   )
 }
 
-To continue, we need to know where your Postgres is running:
+To continue, we need to know where your collector is running:
 
 <SelectCollectorPlatform />
 

--- a/install/google_cloud_sql/03_configure_the_collector.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector.mdx
@@ -40,7 +40,7 @@ export const SelectCollectorPlatform = () => {
   )
 }
 
-To continue, we need to know where your Postgres is running:
+To continue, we need to know where your collector is running:
 
 <SelectCollectorPlatform />
 

--- a/install/self_managed/02_enable_pg_stat_statements.mdx
+++ b/install/self_managed/02_enable_pg_stat_statements.mdx
@@ -47,7 +47,7 @@ export const SelectCollectorPlatform = () => {
 
 In this step we setup [pg_stat_statements](http://www.postgresql.org/docs/current/static/pgstatstatements.html), which is used by pganalyze to collect Postgres query statistics.
 
-To continue, we need to know where your Postgres is running:
+To continue, we need to know where your collector is running:
 
 <SelectCollectorPlatform />
 

--- a/install/self_managed/03_install_the_collector.mdx
+++ b/install/self_managed/03_install_the_collector.mdx
@@ -34,7 +34,7 @@ export const SelectCollectorPlatform = () => {
   )
 }
 
-To continue, we need to know where your Postgres is running:
+To continue, we need to know where your collector is running:
 
 <SelectCollectorPlatform />
 

--- a/install/self_managed/04_configure_the_collector.mdx
+++ b/install/self_managed/04_configure_the_collector.mdx
@@ -40,7 +40,7 @@ export const SelectCollectorPlatform = () => {
   )
 }
 
-To continue, we need to know where your Postgres is running:
+To continue, we need to know where your collector is running:
 
 <SelectCollectorPlatform />
 


### PR DESCRIPTION
This PR does 3 things:

* Update getting started overview: update the "what the collector is" to match to the docs overview page
* ~Update Enabling pg_stat_statements page: this contained some old information, so updated to match modern system~
* Fix typos: "where your Postgres is running" to "where your collector is running"