### PR TITLE
Update RDS step 1 (enabling pg_stat_statements)

### DIFF
--- a/explain/setup/amazon_rds/03_review_settings.mdx
+++ b/explain/setup/amazon_rds/03_review_settings.mdx
@@ -7,8 +7,6 @@ backlink_title: 'Automated EXPLAIN: Setup'
 
 import PgSettingsRecommendations, { getAutoExplainSettingRecommendations } from "../../../components/PgSettingsRecommendations";
 
-import imgRdsParamGroup2 from '../../../images/rds_parameter_group2.gif'
-
 export const AutoExplainLink = ({version, children}) => {
   return (
     <a href={`https://www.postgresql.org/docs/${version ?? 'current'}/auto-explain.html`} target='_blank'>

--- a/install/amazon_rds/_01_public.mdx
+++ b/install/amazon_rds/_01_public.mdx
@@ -30,7 +30,7 @@ but the following is the example of what to modify.
  Name | New Value | &nbsp;
  ---- | ------ | -------
  [pg\_stat\_statements.track](https://www.postgresql.org/docs/current/pgstatstatements.html#PGSTATSTATEMENTS-CONFIG-PARAMS) | ALL | Optional, enables tracking of queries inside stored procedures
- [track\_io\_timing](https://www.postgresql.org/docs/current/runtime-config-statistics.htmlR) | 1 | Optional, enables tracking of per-query I/O statistics
+ [track\_io\_timing](https://www.postgresql.org/docs/current/runtime-config-statistics.html) | 1 | Optional, enables tracking of per-query I/O statistics
  [track\_activity\_query\_size](https://www.postgresql.org/docs/current/runtime-config-statistics.html) | 2048 | Optional, increases the max size of the query strings Postgres records
 
 Find the [parameter group](https://console.aws.amazon.com/rds/home#parameter-groups:id=)

--- a/install/amazon_rds/_01_public.mdx
+++ b/install/amazon_rds/_01_public.mdx
@@ -1,11 +1,3 @@
-import imgRdsParamGroup from '../../images/rds_parameter_group.png'
-import imgRdsEnableParamGroup from '../../images/rds_enable_parameter_group.png'
-
-export const ImgRdsParamGroup = () => <img src={imgRdsParamGroup} />
-
-export const ImgRdsEnableParamGroup = () => <img src={imgRdsEnableParamGroup} />
-
-
 In order to set up pganalyze monitoring for [Amazon RDS](https://aws.amazon.com/rds/postgresql/) you'll need
 to first follow these steps to enable the [pg\_stat\_statements](http://www.postgresql.org/docs/current/static/pgstatstatements.html)
 extension for collecting query statistics.
@@ -16,25 +8,35 @@ This guide assumes you have an already running Amazon RDS PostgreSQL server you 
 
 ## Enabling pg\_stat\_statements
 
-In your [AWS Console](https://console.aws.amazon.com/rds/), modify your existing custom DB Parameter Group, or create a new custom DB Parameter Group:
+Connect to your database as an RDS superuser (usually the credentials you created the database with), e.g. using `psql`.
 
-<ImgRdsParamGroup />
+Run the following SQL commands to enable the extension, and make sure it was installed correctly:
 
----
+```
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+SELECT * FROM pg_stat_statements LIMIT 1;
+```
 
-Then set the following configuration parameters:
+This should return one row of query statistics information.
+
+**Important:** If you get the error `pg_stat_statements must be loaded via shared_preload_libraries`, follow [the troubleshooting document](/docs/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries).
+
+## Review pg\_stat\_statements configuration parameters
+
+There are a number of settings that define how pg\_stat\_statements will collect statistics.
+The right configuration will depend on your server, workload, and preferences,
+but the following is the example of what to modify.
 
  Name | New Value | &nbsp;
  ---- | ------ | -------
- [pg\_stat\_statements.track](https://www.postgresql.org/docs/current/pgstatstatements.html#id-1.11.7.39.9) | ALL | Optional, enables tracking of queries inside stored procedures
-[shared\_preload\_libraries](https://www.postgresql.org/docs/current/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-PRELOAD) | pg\_stat\_statements
- [track\_io\_timing](https://www.postgresql.org/docs/current/runtime-config-statistics.html#RUNTIME-CONFIG-STATISTICS-COLLECTOR) | 1 | Optional, enables tracking of per-query I/O statistics
+ [pg\_stat\_statements.track](https://www.postgresql.org/docs/current/pgstatstatements.html#PGSTATSTATEMENTS-CONFIG-PARAMS) | ALL | Optional, enables tracking of queries inside stored procedures
+ [track\_io\_timing](https://www.postgresql.org/docs/current/runtime-config-statistics.htmlR) | 1 | Optional, enables tracking of per-query I/O statistics
+ [track\_activity\_query\_size](https://www.postgresql.org/docs/current/runtime-config-statistics.html) | 2048 | Optional, increases the max size of the query strings Postgres records
 
----
+Find the [parameter group](https://console.aws.amazon.com/rds/home#parameter-groups:id=)
+for your database and apply the settings above.
 
-In case you created a new parameter group you'll have to modify your database to use the Parameter Group you created earlier:<br />
-
-<ImgRdsEnableParamGroup />
+In case you created a new parameter group you'll have to modify your database to use the Parameter Group you created earlier.
 
 ## Enable Enhanced Monitoring
 
@@ -42,27 +44,6 @@ We also highly recommend turning on Enhanced Monitoring, if you haven't already 
 more detailed system-level statistics that can be helpful, e.g. to debug I/O issues.<br />
 
 If Enhanced Monitoring is enabled, pganalyze will automatically collect and show this additional information in the dashboard as well.
-
-## Reboot your database
-
-To enable the extension you need to reboot your database.
-
-Note that this only needs to be done if you haven't enabled pg\_stat\_statements on this database before.
-
----
-
-## Verify that pg\_stat\_statements is enabled
-
-Connect to your database as an RDS superuser (usually the credentials you created the database with), e.g. using `psql`.
-
-Run the following SQL commands to enable the extension, and make sure it was installed correctly:
-
-```
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
-SELECT * FROM pg_stat_statements LIMIT 1;
-```
-
-This should return one row of query statistics information - if it gives an error you might not have restarted your database or changed the configuration correctly.
 
 ---
 

--- a/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries.mdx
+++ b/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries.mdx
@@ -4,10 +4,12 @@ backlink_href: /docs/install/troubleshooting
 backlink_title: 'Installation Troubleshooting'
 ---
 
-import imgRdsParamGroup from '../../images/rds_parameter_group.png'
-import imgRdsEnableParamGroup from '../../images/rds_enable_parameter_group.png'
+import imgRdsParamGroup from "../../images/rds_parameter_group.png";
+import imgRdsParamGroup from2 "../../images/rds_parameter_group2.gif";
+import imgRdsEnableParamGroup from "../../images/rds_enable_parameter_group.png";
 
 export const ImgRdsParamGroup = () => <img src={imgRdsParamGroup} />
+export const ImgRdsParamGroup2 = () => <img src={imgRdsParamGroup2} />
 export const ImgRdsEnableParamGroup = () => <img src={imgRdsEnableParamGroup} />
 
 You may get the following error when you setup pganalyze, which collects query performance information using pg\_stat\_statements:
@@ -23,7 +25,7 @@ To enable it for a database running on Amazon RDS, go to your [AWS Console](http
 
 In the custom parameter group, modify the `shared_preload_libraries` setting and make sure it includes `pg_stat_statements`.
 
-![](../../images/rds_parameter_group2.gif)
+<ImgRdsParamGroup2 />
 
 In case you created a **new** parameter group you'll have to modify your database to use this new parameter group:
 

--- a/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries.mdx
+++ b/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries.mdx
@@ -5,7 +5,7 @@ backlink_title: 'Installation Troubleshooting'
 ---
 
 import imgRdsParamGroup from "../../images/rds_parameter_group.png";
-import imgRdsParamGroup from2 "../../images/rds_parameter_group2.gif";
+import imgRdsParamGroup2 from "../../images/rds_parameter_group2.gif";
 import imgRdsEnableParamGroup from "../../images/rds_enable_parameter_group.png";
 
 export const ImgRdsParamGroup = () => <img src={imgRdsParamGroup} />

--- a/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries.mdx
+++ b/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries.mdx
@@ -4,14 +4,6 @@ backlink_href: /docs/install/troubleshooting
 backlink_title: 'Installation Troubleshooting'
 ---
 
-import imgRdsParamGroup from "../../images/rds_parameter_group.png";
-import imgRdsParamGroup2 from "../../images/rds_parameter_group2.gif";
-import imgRdsEnableParamGroup from "../../images/rds_enable_parameter_group.png";
-
-export const ImgRdsParamGroup = () => <img src={imgRdsParamGroup} />
-export const ImgRdsParamGroup2 = () => <img src={imgRdsParamGroup2} />
-export const ImgRdsEnableParamGroup = () => <img src={imgRdsEnableParamGroup} />
-
 You may get the following error when you setup pganalyze, which collects query performance information using pg\_stat\_statements:
 
 ```
@@ -21,15 +13,15 @@ ERROR: pg_stat_statements must be loaded via shared_preload_libraries
 This error indicates that you have not fully enabled pg\_stat\_statements in your database yet.
 To enable it for a database running on Amazon RDS, go to your [AWS Console](https://console.aws.amazon.com/rds/), modify your existing custom DB Parameter Group, or create a new custom DB Parameter Group:
 
-<ImgRdsParamGroup />
+![](../../images/rds_parameter_group.png)
 
 In the custom parameter group, modify the `shared_preload_libraries` setting and make sure it includes `pg_stat_statements`.
 
-<ImgRdsParamGroup2 />
+![](../../images/rds_parameter_group2.gif)
 
 In case you created a **new** parameter group you'll have to modify your database to use this new parameter group:
 
-<ImgRdsEnableParamGroup />
+![](../../images/rds_enable_parameter_group.png)
 
 To apply the configuration change you will need to reboot your database.
 

--- a/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries.mdx
+++ b/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries.mdx
@@ -4,18 +4,31 @@ backlink_href: /docs/install/troubleshooting
 backlink_title: 'Installation Troubleshooting'
 ---
 
+import imgRdsParamGroup from '../../images/rds_parameter_group.png'
+import imgRdsEnableParamGroup from '../../images/rds_enable_parameter_group.png'
+
+export const ImgRdsParamGroup = () => <img src={imgRdsParamGroup} />
+export const ImgRdsEnableParamGroup = () => <img src={imgRdsEnableParamGroup} />
+
 You may get the following error when you setup pganalyze, which collects query performance information using pg\_stat\_statements:
 
 ```
 ERROR: pg_stat_statements must be loaded via shared_preload_libraries
 ```
 
-This error indicates that you have not fully enabled pg\_stat\_statements in your database yet. To enable it for a database running on Amazon RDS, go to your [AWS Console](https://console.aws.amazon.com/rds/), modify your existing custom DB Parameter Group, or create a new custom DB Parameter Group.
+This error indicates that you have not fully enabled pg\_stat\_statements in your database yet.
+To enable it for a database running on Amazon RDS, go to your [AWS Console](https://console.aws.amazon.com/rds/), modify your existing custom DB Parameter Group, or create a new custom DB Parameter Group:
+
+<ImgRdsParamGroup />
 
 In the custom parameter group, modify the `shared_preload_libraries` setting and make sure it includes `pg_stat_statements`.
 
 ![](../../images/rds_parameter_group2.gif)
 
-In case you created a **new** parameter group you'll have to modify your database to use this new parameter group. To apply the configuration change you will need to reboot your database.
+In case you created a **new** parameter group you'll have to modify your database to use this new parameter group:
+
+<ImgRdsEnableParamGroup />
+
+To apply the configuration change you will need to reboot your database.
 
 Then re-run `SELECT * FROM pg_stat_statements LIMIT 1` and make sure you get a result.


### PR DESCRIPTION
This mainly update two pages, to match closer for in-app setup steps.
You can find the modified pages in here:

https://pganalyze.com/docs/install/amazon_rds/01_configure_rds_instance

![image](https://github.com/pganalyze/pganalyze-docs/assets/911433/3698d1fe-f480-43a7-9ae0-521ca3cd90a4)


https://pganalyze.com/docs/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries

![image](https://github.com/pganalyze/pganalyze-docs/assets/911433/9fbb02dd-6902-4a30-a178-063412784564)
