### PR TITLE
Fix extended statistics monitoring helpers for Postgres 12

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -76,7 +76,7 @@ CREATE OR REPLACE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
   most_common_val_nulls boolean[], most_common_freqs float8[], most_common_base_freqs float8[]
 ) AS
 $$
-  /* pganalyze-collector */ SELECT statistics_schemaname, statistics_name,
+  /* pganalyze-collector */ SELECT statistics_schemaname::text, statistics_name::text,
   (row_to_json(se.*)::jsonb ->> 'inherited')::boolean AS inherited, n_distinct, dependencies,
   most_common_val_nulls, most_common_freqs, most_common_base_freqs
   FROM pg_catalog.pg_stats_ext se;


### PR DESCRIPTION
Our get_relation_stats_ext helper is specified as returning a row that
starts with two text fields, but these come from the pg_stats_ext view
and are actually `name` columns (the type for Postgres identifiers).

Postgres 13 introduced an implicit name-to-text cast, so in that version
and newer versions, our helper function works fine, but on Postgres 12
it fails with

ERROR:  return type mismatch in function declared to return record
DETAIL:  Final statement returns name instead of text at column 1.
CONTEXT:  SQL function "get_relation_stats_ext"

Update the function definition to use explicit casts for the first two
columns.
