### PR TITLE
Don't generate replication helper if pg_monitor is available

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -185,7 +185,12 @@ const MonitoringUserBase: React.FunctionComponent<{
 ${noPgMonitor ? '' : 'GRANT pg_monitor TO pganalyze;\n'}
 CREATE SCHEMA pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO pganalyze;
-GRANT USAGE ON SCHEMA public TO pganalyze;`}
+GRANT USAGE ON SCHEMA public TO pganalyze;
+
+${noPgMonitor ? `CREATE OR REPLACE FUNCTION pganalyze.get_stat_replication() RETURNS SETOF pg_stat_replication AS
+$$
+  /* pganalyze-collector */ SELECT * FROM pg_catalog.pg_stat_replication;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;` : ''}`}
       </CodeBlock>
       <p>
         If you enable the optional reset mode (usually not required), you will also need this helper method:


### PR DESCRIPTION
The pg_monitor role already grants access to this, so the helper is
superfluous.
