### PR TITLE
Create a dedicated page for IAM policy

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -620,6 +620,10 @@
       "title": "Step 4: Configure the Collector",
       "path": "/docs/install/amazon_rds/04_configure_the_collector_ecs"
     },
+    "install/amazon_rds/iam_policy": {
+      "title": "Amazon RDS and Aurora: IAM Policy",
+      "path": "/docs/install/amazon_rds/iam_policy"
+    },
     "install/azure_database/01_configure_azure_instance": {
       "title": "Step 1: Configure Azure Database for PostgreSQL Instance",
       "path": "/docs/install/azure_database/01_configure_azure_instance"

--- a/enterprise/settings.mdx
+++ b/enterprise/settings.mdx
@@ -65,7 +65,7 @@ You can also configure the following object storage settings:
 * `AWS_S3_SNAPSHOTS_PREFIX`: Prefix for all objects stored in snapshots bucket (optional, empty by default)
 * `AWS_S3_LOGS_PREFIX`: Prefix for all objects stored in logs bucket (optional, empty by default)
 
-Note that when using the collector inside the Enterprise Server container to monitor Amazon RDS or Aurora, the actual fetching of log data from RDS will also use these same credentials. Ensure to also set the [collector IAM policy](/docs/install/amazon_rds/03_setup_iam_policy) in that case.
+Note that when using the collector inside the Enterprise Server container to monitor Amazon RDS or Aurora, the actual fetching of log data from RDS will also use these same credentials. Ensure to also set the [collector IAM policy](/docs/install/amazon_rds/iam_policy) in that case.
 
 In addition, you can also set these other general settings:
 

--- a/enterprise/setup/index.mdx
+++ b/enterprise/setup/index.mdx
@@ -26,7 +26,7 @@ The pganalyze container image is mostly self-contained, and runs various service
   * 50 GB of dedicated disk space or more
 * Optional: If you use the RDS integration, set up an appropriate IAM role that can be used to download logs and system metrics
   * You can also assign the required policy to an existing EC2 instance and its instance role
-  * You will need both the [collector IAM policy](/docs/install/amazon_rds/03_setup_iam_policy) as well as the [object storage IAM policy](/docs/enterprise/setup/object-storage-s3)
+  * You will need both the [collector IAM policy](/docs/install/amazon_rds/iam_policy) as well as the [object storage IAM policy](/docs/enterprise/setup/object-storage-s3)
 
 ### Step 1: Download the container image
 
@@ -102,9 +102,9 @@ If you get permission errors, you may need to create the extensions `btree_gist`
 Jul  2 07:15:16 aa84f55aceba syslog-ng[160]: syslog-ng starting up; version='3.13.2'
 Jul  2 07:15:17 aa84f55aceba cron[180]: (CRON) INFO (pidfile fd = 3)
 Jul  2 07:15:17 aa84f55aceba cron[180]: (CRON) INFO (Running @reboot jobs)
- set_config 
+ set_config
 ------------
- 
+
 (1 row)
 
 Jul  2 07:15:22 aa84f55aceba syslog-ng[160]: syslog-ng shutting down; version='3.13.2'
@@ -128,12 +128,12 @@ Jul  2 07:15:30 8bc5a4c0e6b6 cron[167]: (CRON) INFO (Running @reboot jobs)
 I, [2020-07-02T07:15:35.006455 #159]  INFO -- : *****************************
 I, [2020-07-02T07:15:35.006520 #159]  INFO -- : *** INITIAL ADMIN CREATED ***
 I, [2020-07-02T07:15:35.006538 #159]  INFO -- : *****************************
-I, [2020-07-02T07:15:35.006551 #159]  INFO -- : 
+I, [2020-07-02T07:15:35.006551 #159]  INFO -- :
 I, [2020-07-02T07:15:35.006563 #159]  INFO -- : *****************************
 I, [2020-07-02T07:15:35.006599 #159]  INFO -- : Email:    admin@example.com
 I, [2020-07-02T07:15:35.006619 #159]  INFO -- : Password: abcdefabcdef
 I, [2020-07-02T07:15:35.006636 #159]  INFO -- : *****************************
-I, [2020-07-02T07:15:35.006648 #159]  INFO -- : 
+I, [2020-07-02T07:15:35.006648 #159]  INFO -- :
 I, [2020-07-02T07:15:35.006660 #159]  INFO -- : Use these credentials to login and then change email address and password.
 Jul  2 07:15:35 8bc5a4c0e6b6 syslog-ng[150]: syslog-ng shutting down; version='3.13.2'
 ```

--- a/install.mdx
+++ b/install.mdx
@@ -21,6 +21,9 @@ To continue please select in which environment you are running your Postgres dat
       <li>
         <Link to="install/01_enabling_pg_stat_statements">Enable pg_stat_statements</Link>
       </li>
+      <li>
+        <Link to="install/amazon_rds/iam_policy">Amazon RDS and Aurora: IAM Policy</Link>
+      </li>
     </ul>
   </div>
 </PublicOnly>

--- a/install/amazon_rds/_03_setup_iam_policy.mdx
+++ b/install/amazon_rds/_03_setup_iam_policy.mdx
@@ -36,3 +36,5 @@ This policy grants the following access:
 - RDS metadata used to discover general instance information
 - Cloudwatch metrics to show CPU utilization and other system metrics in pganalyze
 - RDS log file download (for [pganalyze Log Insights](https://pganalyze.com/log-insights))
+
+To learn more about each access, see [Amazon RDS and Aurora: IAM Policy](/docs/install/amazon_rds/iam_policy).

--- a/install/amazon_rds/iam_policy.mdx
+++ b/install/amazon_rds/iam_policy.mdx
@@ -1,0 +1,99 @@
+---
+title: 'Amazon RDS and Aurora: IAM Policy'
+install_track_title: Installation Guide (Amazon RDS and Amazon Aurora)
+backlink_href: /docs/install
+backlink_title: 'Installation Guide'
+---
+
+The pganalyze collector requires an appropriate IAM policy and role to collect
+the following data of the Amazon RDS or Aurora instances using the AWS API.
+
+<table>
+  <thead>
+    <tr>
+      <th>Action</th>
+      <th>Purpose</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>cloudwatch:GetMetricStatistics</code>, <code>logs:GetLogEvents</code></td>
+      <td>
+        For system metrics data shown in System page in pganalyze, such as I/O
+        utilization. When Enhanced Monitoring is turned on, <code>logs:GetLogEvents</code>
+        will be used to obtain CPU, Memory, Storage and Network information
+        through the <code>RDSOSMetrics</code> log group.
+      </td>
+    </tr>
+    <tr>
+      <td><code>rds:DownloadDBLogFilePortion</code>, <code>rds:DescribeDBLogFiles</code></td>
+      <td>
+        This allows the collector to download the RDS log file, which will be
+        used for the <a href="https://pganalyze.com/log-insights">Log Insights</a>
+        and various other features based on it, such as Automated EXPLAIN.
+      </td>
+    </tr>
+    <tr>
+      <td><code>rds:DescribeDBParameters</code></td>
+      <td>
+        For config parameter data shown in Config Settings page in pganalyze.
+        Knowing the current database config parameters helps pganalyze to give
+        better insights and recommendations.
+      </td>
+    </tr>
+    <tr>
+      <td><code>rds:DescribeDBInstances</code>, <code>rds:DescribeDBClusters</code></td>
+      <td>
+        For RDS or Aurora metadata to discover general instance information.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+Below is a typical IAM policy for the collector. Adjust the actions and/or
+resources as necessary to tailor the permissions to your needs.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "cloudwatch:GetMetricStatistics"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:GetLogEvents"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:logs:*:*:log-group:RDSOSMetrics:log-stream:*"
+        },
+        {
+            "Action": [
+                "rds:DescribeDBParameters"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:rds:*:*:pg:*"
+        },
+        {
+            "Action": [
+                "rds:DescribeDBInstances",
+                "rds:DownloadDBLogFilePortion",
+                "rds:DescribeDBLogFiles"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:rds:*:*:db:*"
+        },
+        {
+            "Action": [
+                "rds:DescribeDBClusters"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:rds:*:*:cluster:*"
+        }
+    ]
+}
+```

--- a/install/amazon_rds/iam_policy.mdx
+++ b/install/amazon_rds/iam_policy.mdx
@@ -6,7 +6,7 @@ backlink_title: 'Installation Guide'
 ---
 
 The pganalyze collector requires an appropriate IAM policy and role to collect
-the following data of the Amazon RDS or Aurora instances using the AWS API.
+the following data from Amazon RDS or Aurora instances using the AWS API.
 
 <table>
   <thead>
@@ -28,8 +28,8 @@ the following data of the Amazon RDS or Aurora instances using the AWS API.
     <tr>
       <td><code>rds:DownloadDBLogFilePortion</code>, <code>rds:DescribeDBLogFiles</code></td>
       <td>
-        This allows the collector to download the RDS log file, which will be
-        used for the <a href="https://pganalyze.com/log-insights">Log Insights</a>
+        This allows the collector to download RDS log files, which will be
+        used for <a href="https://pganalyze.com/log-insights">Log Insights</a>
         and various other features based on it, such as Automated EXPLAIN.
       </td>
     </tr>
@@ -37,7 +37,7 @@ the following data of the Amazon RDS or Aurora instances using the AWS API.
       <td><code>rds:DescribeDBParameters</code></td>
       <td>
         For config parameter data shown in Config Settings page in pganalyze.
-        Knowing the current database config parameters helps pganalyze to give
+        Knowing the current database config parameters helps pganalyze generate
         better insights and recommendations.
       </td>
     </tr>

--- a/log-insights/setup/amazon-rds/01_test_log_download.mdx
+++ b/log-insights/setup/amazon-rds/01_test_log_download.mdx
@@ -32,7 +32,7 @@ The collector will start sending logs shortly.
   </p>
 </PublicOnly>
 
-In case you get permission errors, make sure your IAM user has the [appropriate policy associated](/docs/install/amazon_rds/03_setup_iam_policy).
+In case you get permission errors, make sure your IAM user has the [appropriate policy associated](/docs/install/amazon_rds/iam_policy).
 
 <PublicOnly>
   <p>You will then see Log Insights data on your database within a few minutes:</p>


### PR DESCRIPTION
Successor of https://github.com/pganalyze/pganalyze-docs/pull/243
This PR introduces a new page called "Amazon RDS and Aurora: IAM Policy" (title can be changed), to describe about the IAM policy required for the pganalyze collector.

https://pganalyze-we-iam-policy-rewlpw.herokuapp.com/docs/install/amazon_rds/iam_policy