### PR TITLE
Consolidate per-database helper function instructions

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -69,6 +69,76 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
   );
 };
 
+export const MonitoringUserColumnStats: React.FunctionComponent<{ username: string, adminUsername: string }> = ({
+  username,
+  adminUsername
+}) => {
+  const adminUserStr = !!adminUsername ? <strong>{adminUsername}</strong> : 'a superuser (or equivalent)'
+  const CodeBlock = useCodeBlock();
+  return (
+    <>
+      <p>
+        Then, connect to each database that you plan to monitor on this server as {adminUserStr} and
+        run the following to enable the collection of additional column statistics:
+      </p>
+      <CodeBlock>
+        {`CREATE SCHEMA IF NOT EXISTS pganalyze;
+GRANT USAGE ON SCHEMA pganalyze TO ${username};
+CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
+$$
+  /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
+    n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
+    most_common_elem_freqs, elem_count_histogram
+  FROM pg_catalog.pg_stats;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
+      </CodeBlock>
+      <p>
+        <strong>Note:</strong> We never collect actual table data through this method (see the <code>NULL</code> values in the function), but we do collect statistics about the distribution of values in your tables.
+        You can skip creating the <code>get_column_stats</code> helper function if the database
+        contains highly sensitive information and statistics about it should not be collected.
+        This will impact the accuracy of Index Advisor recommendations.
+      </p>
+    </>
+  );
+};
+
+export const MonitoringUserExtStats: React.FunctionComponent<{ username: string, adminUsername: string }> = ({
+  username,
+  adminUsername
+}) => {
+  const adminUserStr = !!adminUsername ? <strong>{adminUsername}</strong> : 'a superuser (or equivalent)'
+  const CodeBlock = useCodeBlock();
+  return (
+    <>
+      <p>
+        Then, connect to each database that you plan to monitor on this server as {adminUserStr} and
+        run the following to enable the collection of additional extended statistics:
+      </p>
+      <CodeBlock>
+        {`CREATE SCHEMA IF NOT EXISTS pganalyze;
+GRANT USAGE ON SCHEMA pganalyze TO ${username};
+CREATE OR REPLACE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
+  statistics_schemaname text, statistics_name text,
+  inherited boolean, n_distinct pg_ndistinct, dependencies pg_dependencies,
+  most_common_val_nulls boolean[], most_common_freqs float8[], most_common_base_freqs float8[]
+) AS
+$$
+  /* pganalyze-collector */ SELECT statistics_schemaname::text, statistics_name::text,
+  (row_to_json(se.*)::jsonb ->> 'inherited')::boolean AS inherited, n_distinct, dependencies,
+  most_common_val_nulls, most_common_freqs, most_common_base_freqs
+  FROM pg_catalog.pg_stats_ext se;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
+      </CodeBlock>
+      <p>
+        <strong>Note:</strong> We never collect actual table data through this method (we omit fetching fields like <code>most_common_vals</code> from the <code>pg_stats_ext</code> view, as you can see in the function definition), but we do collect statistics about the distribution of values in your tables.
+        You can skip creating the <code>get_relation_stats_ext</code> helper function if the database
+        contains highly sensitive information and statistics about it should not be collected.
+        This will impact the accuracy of Index Advisor recommendations.
+      </p>
+    </>
+  );
+};
+
 export const MonitoringUserExplain: React.FunctionComponent<{ username: string }> = ({username}) => {
   const CodeBlock = useCodeBlock();
   return (

--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -16,13 +16,12 @@ const MonitoringUserSetupInstructions: React.FunctionComponent<Props> = ({
   return (
     <>
       <MonitoringUserBase password={password} noPgMonitor={noPgMonitor} />
-      <MonitoringUserColumnStats username="pganalyze" adminUsername={adminUsername} />
-      <MonitoringUserExtStats username="pganalyze" adminUsername={adminUsername} />
+      <MonitoringUserPerDatabaseHelpers username="pganalyze" adminUsername={adminUsername} />
     </>
   );
 };
 
-export const MonitoringUserColumnStats: React.FunctionComponent<{ username: string, adminUsername: string }> = ({
+export const MonitoringUserPerDatabaseHelpers: React.FunctionComponent<{ username: string, adminUsername: string }> = ({
   username,
   adminUsername
 }) => {
@@ -32,44 +31,20 @@ export const MonitoringUserColumnStats: React.FunctionComponent<{ username: stri
     <>
       <p>
         Then, connect to each database that you plan to monitor on this server as {adminUserStr} and
-        run the following to enable the collection of additional column statistics:
+        run the following to enable the collection of additional column statistics and extended statistics:
       </p>
       <CodeBlock>
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
+
 CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
 $$
   /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
     n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
     most_common_elem_freqs, elem_count_histogram
   FROM pg_catalog.pg_stats;
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
-      </CodeBlock>
-      <p>
-        <strong>Note:</strong> We never collect actual table data through this method (see the <code>NULL</code> values in the function), but we do collect statistics about the distribution of values in your tables.
-        You can skip creating the <code>get_column_stats</code> helper function if the database
-        contains highly sensitive information and statistics about it should not be collected.
-        This will impact the accuracy of Index Advisor recommendations.
-      </p>
-    </>
-  );
-};
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 
-export const MonitoringUserExtStats: React.FunctionComponent<{ username: string, adminUsername: string }> = ({
-  username,
-  adminUsername
-}) => {
-  const adminUserStr = !!adminUsername ? <strong>{adminUsername}</strong> : 'a superuser (or equivalent)'
-  const CodeBlock = useCodeBlock();
-  return (
-    <>
-      <p>
-        Then, connect to each database that you plan to monitor on this server as {adminUserStr} and
-        run the following to enable the collection of additional extended statistics:
-      </p>
-      <CodeBlock>
-        {`CREATE SCHEMA IF NOT EXISTS pganalyze;
-GRANT USAGE ON SCHEMA pganalyze TO ${username};
 CREATE OR REPLACE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
   statistics_schemaname text, statistics_name text,
   inherited boolean, n_distinct pg_ndistinct, dependencies pg_dependencies,
@@ -83,9 +58,11 @@ $$
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
       </CodeBlock>
       <p>
-        <strong>Note:</strong> We never collect actual table data through this method (we omit fetching fields like <code>most_common_vals</code> from the <code>pg_stats_ext</code> view, as you can see in the function definition), but we do collect statistics about the distribution of values in your tables.
-        You can skip creating the <code>get_relation_stats_ext</code> helper function if the database
-        contains highly sensitive information and statistics about it should not be collected.
+        <strong>Note:</strong> We never collect actual table data through this method (see the <code>NULL</code> values
+        in the <code>get_column_stats</code> function and omitted fields like <code>most_common_vals</code> in
+        the <code>get_relation_stats_ext</code> function), but we do collect statistics about the distribution of
+        values in your tables. You can skip creating the <code>get_column_stats</code> and <code>get_relation_stats_ext</code> helper
+        functions if the database contains highly sensitive information and statistics about it should not be collected.
         This will impact the accuracy of Index Advisor recommendations.
       </p>
     </>

--- a/install/crunchy_bridge/01_deploy_the_collector.mdx
+++ b/install/crunchy_bridge/01_deploy_the_collector.mdx
@@ -6,7 +6,7 @@ backlink_title: 'Installation Guide'
 ---
 
 import PublicLastStepLogInsightsLink from '../_public_last_step_log_insights_link.mdx';
-import { MonitoringUserColumnStats, MonitoringUserLogRead, MonitoringUserExtStats } from "../../components/MonitoringUserSetupInstructions";
+import { MonitoringUserLogRead, MonitoringUserPerDatabaseHelpers } from "../../components/MonitoringUserSetupInstructions";
 
 export const CollectorStartCommand = ({ apiKey, cmd, logExplain }) => {
   return (
@@ -33,9 +33,7 @@ Additionally, run the following to allow the application user to read the Postgr
 
 <MonitoringUserLogRead username="application" />
 
-<MonitoringUserColumnStats username="application" />
-
-<MonitoringUserExtStats username="application" />
+<MonitoringUserPerDatabaseHelpers username="pganalyze" />
 
 In later steps you can now specify the application user credentials as the `DB_URL`.
 


### PR DESCRIPTION
Currently, we prompt users to create helper functions to access column
stats and extended statistics separately, even though both of these
have to be created per-database.

Consolidate these, so users only have to iterate through their
databases once.
