### PR TITLE
docs: set user id to 1000 on the ecs task

### DIFF
--- a/install/amazon_rds/_04_setting_env_vars_multi_ecs.mdx
+++ b/install/amazon_rds/_04_setting_env_vars_multi_ecs.mdx
@@ -71,6 +71,7 @@ Now, save the following ECS task definition to a file, for example `pganalyze_ta
           "awslogs-stream-prefix": "pganalyze"
         }
       },
+      "user": 1000,
       "readonlyRootFilesystem": false,
       "mountPoints": []
     }

--- a/install/amazon_rds/_04_setting_env_vars_single_ecs.mdx
+++ b/install/amazon_rds/_04_setting_env_vars_single_ecs.mdx
@@ -66,6 +66,7 @@ Now, save the following ECS task definition to a file, for example `pganalyze_ta
           "awslogs-stream-prefix": "pganalyze"
         }
       },
+      "user": 1000,
       "readonlyRootFilesystem": false,
       "mountPoints": []
     }


### PR DESCRIPTION
Minor improvement for the ecs documentation. If the user is not set to "1000", by default it will be the user with id 0 and this part of the collector entrypoint.sh will execute: https://github.com/pganalyze/collector/blob/main/contrib/docker-entrypoint.sh#L10-L12

This is a problem because it crashes on startup with the following error: 
```
/ $ setpriv --reuid=pganalyze --regid=pganalyze --inh-caps=-all --clear-groups
setpriv: unrecognized option: reuid=pganalyze
BusyBox v1.36.1 (2023-11-06 11:32:24 UTC) multi-call binary.

Usage: setpriv [OPTIONS] PROG ARGS

Run PROG with different privilege settings

-d,--dump               Show current capabilities
--nnp,--no-new-privs    Ignore setuid/setgid bits and file capabilities
--inh-caps CAP,CAP      Set inheritable capabilities
--ambient-caps CAP,CAP  Set ambient capabilities
```