### PR TITLE
Update stale links and point to auto explain

### DIFF
--- a/log-insights/setup/aiven/04_configure_service_integration.mdx
+++ b/log-insights/setup/aiven/04_configure_service_integration.mdx
@@ -72,5 +72,8 @@ show your integration as active:
   <p>
     We recommend setting up <a href="/docs/explain/setup/log_explain">Log-based EXPLAIN</a> as
     a follow-up step, to automatically EXPLAIN slow queries in Postgres.
+    As an alternative to Log-based EXPLAIN, you can integrate the auto_explain module with
+    <a href="https://github.com/aiven/aiven-extras?tab=readme-ov-file#examples">some changes</a> to
+    your application.
   </p>
 </PublicOnly>

--- a/log-insights/setup/aiven/04_configure_service_integration.mdx
+++ b/log-insights/setup/aiven/04_configure_service_integration.mdx
@@ -70,7 +70,7 @@ show your integration as active:
     <ImgLogInsightsScreenshot />
   </p>
   <p>
-    We recommend setting up <a href="/docs/explain/setup">Automated EXPLAIN</a> as
+    We recommend setting up <a href="/docs/explain/setup/log_explain">Log-based EXPLAIN</a> as
     a follow-up step, to automatically EXPLAIN slow queries in Postgres.
   </p>
 </PublicOnly>

--- a/log-insights/setup/azure-database/05_configure_collector.mdx
+++ b/log-insights/setup/azure-database/05_configure_collector.mdx
@@ -29,7 +29,7 @@ For additional help when you get an error please check our
 <PublicOnly>
   <p>You will start seeing log data in pganalyze Log Insights within a few minutes.</p>
   <p>
-    We recommend setting up <a href="/docs/explain/setup/log_explain/01_create_helper_functions">Log-based EXPLAIN</a>{" "}
-    as follow-up step, to automatically EXPLAIN slow queries in Postgres.
+    We recommend setting up <a href="/docs/explain/setup/azure_database/01_auto_explain_check">Automated EXPLAIN</a> as
+    a follow-up step, to automatically EXPLAIN slow queries in Postgres.
   </p>
 </PublicOnly>

--- a/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test.mdx
+++ b/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test.mdx
@@ -49,7 +49,7 @@ Note the "Log test successful", which indicates that the helper method works cor
 <PublicOnly>
   <p>You will start seeing log data in pganalyze Log Insights within a few minutes.</p>
   <p>
-    We recommend setting up <a href="/docs/explain/setup/crunchy_bridge/01_create_helper_functions">Log-based EXPLAIN</a>{" "}
-    as follow-up step, to automatically EXPLAIN slow queries in Postgres.
+    We recommend setting up <a href="/docs/explain/setup/crunchy_bridge/01_auto_explain_check">Automated EXPLAIN</a> as
+    a follow-up step, to automatically EXPLAIN slow queries in Postgres.
   </p>
 </PublicOnly>

--- a/log-insights/setup/google-cloud-sql/04_configure_collector.mdx
+++ b/log-insights/setup/google-cloud-sql/04_configure_collector.mdx
@@ -24,7 +24,7 @@ For additional help when you get an error please check our
 <PublicOnly>
   <p>You will start seeing log data in pganalyze Log Insights within a few minutes.</p>
   <p>
-    We recommend setting up <a href="/docs/explain/setup/log_explain">Log-based EXPLAIN</a> as
+    We recommend setting up <a href="/docs/explain/setup/google_cloud_sql/01_auto_explain_check">Automated EXPLAIN</a> as
     a follow-up step, to automatically EXPLAIN slow queries in Postgres.
   </p>
 </PublicOnly>


### PR DESCRIPTION
This has been bothering me quite a bit, let's update old links.

* Azure, Crunchy, Google => they have auto explain, so let's link to auto explain page
* Aiven => they actually don't support auto explain, so let's link to log based explain page