### PR TITLE
Remove --reload flag from the collector tests

### DIFF
--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -24,9 +24,9 @@ describe the servers to monitor, how to connect to them, and server-specific con
 name the other sections after the servers they correspond to, though note these are not the names that will appear
 in the app. In-app names are based on hostname settings as determined during monitoring.
 
-After you make changes, you can run `pganalyze-collector --test` to verify the new configuration and load
-the new configuration in the collector background process if they work correctly. Successful test run will reload the collector.
-This minimizes monitoring interruptions and simplifies config file updates.
+After you make changes, you can run `pganalyze-collector --test` to verify the new configuration.
+If the test succeeds, this will automatically load the new configuration in the collector background process
+(equivalent to using the `--reload` flag). This minimizes monitoring interruptions and simplifies config file updates.
 
 The tables below list configuration settings, their defaults if not set, and their descriptions. If a setting is
 configurable through environment variables, the environment variable name follows the setting in parentheses.

--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -24,9 +24,9 @@ describe the servers to monitor, how to connect to them, and server-specific con
 name the other sections after the servers they correspond to, though note these are not the names that will appear
 in the app. In-app names are based on hostname settings as determined during monitoring.
 
-After you make changes, you can run `pganalyze-collector --test --reload` to verify the new configuration and load
-the new configuration in the collector background process if they work correctly. This minimizes monitoring
-interruptions and simplifies config file updates.
+After you make changes, you can run `pganalyze-collector --test` to verify the new configuration and load
+the new configuration in the collector background process if they work correctly. Successful test run will reload the collector.
+This minimizes monitoring interruptions and simplifies config file updates.
 
 The tables below list configuration settings, their defaults if not set, and their descriptions. If a setting is
 configurable through environment variables, the environment variable name follows the setting in parentheses.

--- a/components/CollectorLogTest.tsx
+++ b/components/CollectorLogTest.tsx
@@ -17,7 +17,7 @@ I Successfully reloaded pganalyze collector (PID 123)`
           and apply the collector configuration (for container environments, simply
           restart the collector):
         </p>
-        <CodeBlock>sudo pganalyze-collector --test --reload</CodeBlock>
+        <CodeBlock>sudo pganalyze-collector --test</CodeBlock>
         <CodeBlock>{sampleOutput}</CodeBlock>
       </>
     )
@@ -34,7 +34,7 @@ I Successfully reloaded pganalyze collector (PID 123)`
     return (
       <>
         <p>You can now test and apply the collector configuration:</p>
-        <CodeBlock>sudo pganalyze-collector --test --reload</CodeBlock>
+        <CodeBlock>sudo pganalyze-collector --test</CodeBlock>
         <CodeBlock>{sampleOutput}</CodeBlock>
         <p>
           If you are getting an error, it sometimes helps to run the

--- a/components/CollectorSettings.tsx
+++ b/components/CollectorSettings.tsx
@@ -8,7 +8,7 @@ const CollectorSettings: React.FunctionComponent<{settings: CollectorSetting[], 
     return (
       <div>
         <p>
-          If using the config file, make the following changes, typically in <code>/etc/pganalyze-collector.conf</code>:
+          If using the config file, make the following changes, typically in <code>/etc/pganalyze-collector.conf</code>, under the server section:
         </p>
         <CollectorConfigFileSettings settings={settings} />
         <p>
@@ -27,7 +27,7 @@ const CollectorSettings: React.FunctionComponent<{settings: CollectorSetting[], 
   } else if (!configFromEnv) {
     return (
       <div>
-        <p>Make the following changes to your <code>pganalyze-collector.conf</code>:</p>
+        <p>Make the following changes to your <code>pganalyze-collector.conf</code>, under the server section:</p>
         <CollectorConfigFileSettings settings={settings} />
       </div>
     )
@@ -83,7 +83,7 @@ function toEnvSetting(configFileSetting: string):string {
       return 'PGA_' + configFileSetting.toUpperCase();
     default:
       return configFileSetting.toUpperCase();
-  }  
+  }
 }
 
 export default CollectorSettings

--- a/components/CollectorSettings.tsx
+++ b/components/CollectorSettings.tsx
@@ -8,7 +8,7 @@ const CollectorSettings: React.FunctionComponent<{settings: CollectorSetting[], 
     return (
       <div>
         <p>
-          If using the config file, make the following changes, typically in <code>/etc/pganalyze-collector.conf</code>, under the server section:
+          If using the config file, make the following changes, typically in <code>/etc/pganalyze-collector.conf</code>:
         </p>
         <CollectorConfigFileSettings settings={settings} />
         <p>
@@ -27,7 +27,7 @@ const CollectorSettings: React.FunctionComponent<{settings: CollectorSetting[], 
   } else if (!configFromEnv) {
     return (
       <div>
-        <p>Make the following changes to your <code>pganalyze-collector.conf</code>, under the server section:</p>
+        <p>Make the following changes to your <code>pganalyze-collector.conf</code>:</p>
         <CollectorConfigFileSettings settings={settings} />
       </div>
     )
@@ -83,7 +83,7 @@ function toEnvSetting(configFileSetting: string):string {
       return 'PGA_' + configFileSetting.toUpperCase();
     default:
       return configFileSetting.toUpperCase();
-  }
+  }  
 }
 
 export default CollectorSettings

--- a/explain/setup/log_explain/02_enable_log_explain.mdx
+++ b/explain/setup/log_explain/02_enable_log_explain.mdx
@@ -16,9 +16,10 @@ You will need to update the collector configuration to enable log-based EXPLAIN.
 Afterwards make sure to reload the pganalyze collector, so the setting takes effect:
 
 ```
-sudo pganalyze-collector --test --reload
+sudo pganalyze-collector --test
 ```
 
+Successful test run will reload the collector.
 If this test succeeds, continue to the next step to test plan collection:
 
 <Link className='btn btn-success' to='03_test_and_verify'>

--- a/install/aiven/05_configure_the_collector_package.mdx
+++ b/install/aiven/05_configure_the_collector_package.mdx
@@ -61,7 +61,7 @@ Fill in the values from the info in your Aiven console:
 Run the following to make sure the configuration works:
 
 ```
-sudo pganalyze-collector --test --reload
+sudo pganalyze-collector --test
 ```
 
 <PublicLastStepLogInsightsLink />

--- a/install/amazon_rds/04_configure_the_collector_ec2.mdx
+++ b/install/amazon_rds/04_configure_the_collector_ec2.mdx
@@ -91,7 +91,7 @@ db_host = mydbinstance3.123456789012.us-east-1.rds.amazonaws.com
 Now, verify that the configuration is correct, by running the following command:
 
 ```
-$ sudo pganalyze-collector --test --reload
+$ sudo pganalyze-collector --test
 1999/01/01 08:04:30 I [pganalyze] Testing statistics collection...
 1999/01/01 08:04:32 I [pganalyze] Test submission successful (1010 KB received)
 ```

--- a/install/azure_database/04_configure_the_collector_package.mdx
+++ b/install/azure_database/04_configure_the_collector_package.mdx
@@ -55,7 +55,7 @@ Fill in the values step-by-step:
 Run the following to make sure the configuration works:
 
 ```
-sudo pganalyze-collector --test --reload
+sudo pganalyze-collector --test
 ```
 
 <PublicLastStepLogInsightsLink />

--- a/install/google_cloud_sql/03_configure_the_collector_package.mdx
+++ b/install/google_cloud_sql/03_configure_the_collector_package.mdx
@@ -61,7 +61,7 @@ If you are using Google AlloyDB, do not specify `gcp_cloudsql_instance_id`, but 
 Run the following to make sure the configuration works:
 
 ```
-sudo pganalyze-collector --test --reload
+sudo pganalyze-collector --test
 ```
 
 <PublicLastStepLogInsightsLink />

--- a/install/self_managed/04_configure_the_collector_package.mdx
+++ b/install/self_managed/04_configure_the_collector_package.mdx
@@ -53,7 +53,7 @@ Fill in the values step-by-step:
 Run the following to make sure the configuration works:
 
 ```
-sudo pganalyze-collector --test --reload
+sudo pganalyze-collector --test
 ```
 
 <PublicLastStepLogInsightsLink />


### PR DESCRIPTION
The default behavior now reload config without passing `--reload` flag with successful run, so let's remove `--reload` flag to avoid confusion:
https://github.com/pganalyze/collector/blob/main/CHANGELOG.md#0500------2023-06-05

Also tweaked a bit about where to update the collector config (it should be safe to say "under the server section").