### PR TITLE
Fix EXPLAIN Limit node docs

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -2285,13 +2285,8 @@
       "path": "/docs/explain/scan-nodes/index-scan"
     },
     "Limit": {
-      "shortDescription": "Sorts the output of a child node.",
-      "importantFields": [
-        "Sort Key",
-        "Sort Method",
-        "Sort Space Type",
-        "Sort Space Used"
-      ],
+      "shortDescription": "Return only some of the rows produced by a child.",
+      "importantFields": [],
       "path": "/docs/explain/other-nodes/limit"
     },
     "Lock Rows": {

--- a/explain/other-nodes/limit.mdx
+++ b/explain/other-nodes/limit.mdx
@@ -1,7 +1,7 @@
 ---
 plan_node: Limit
-short_description: Sorts the output of a child node.
-important_fields: Sort Key, Sort Method, Sort Space Type, Sort Space Used
+short_description: Return only some of the rows produced by a child.
+important_fields:
 title: EXPLAIN - Limit
 backlink_href: /docs/explain/other-nodes
 backlink_title: 'Documentation: EXPLAIN - Other Nodes'
@@ -9,11 +9,4 @@ backlink_title: 'Documentation: EXPLAIN - Other Nodes'
 
 **Description:**
 
-Takes data from a child node and produces sorted output, using either memory if available (depending on the `work_mem` setting) or “spilling” to disk. This is obviously necessary if the output needs to be sorted, though sometimes the input can be scanned in an already-sorted manner instead—e.g., if scanning a btree index compatible with the desired sort order.
-
-**Important Fields:**
-
-- Sort Key
-- Sort Method
-- Sort Space Type
-- Sort Space Used
+Return only some of the rows produced by a child. Note that because a limit does not run a child node to completion, the Limit’s own cost may be lower than a child’s cost.


### PR DESCRIPTION
Looks like this got mixed up in
aa025a5e6006b944699046d09a37105d7807b067. Reviewing that commit's
EXPLAIN docs changes, I did not find any similar problems.
