### PR TITLE
Update Heroku deployment link

### DIFF
--- a/components/SmartAnchor.tsx
+++ b/components/SmartAnchor.tsx
@@ -61,7 +61,7 @@ const SmartAnchor: React.FunctionComponent<Props> = ({linkComponent, linkRelativ
 
     const { children, className, ...otherProps } = props;
     // Don't show external icon link in some situations
-    const skipExternalLinkIcon = destination.startsWith('https://heroku.com/deploy')
+    const skipExternalLinkIcon = destination.startsWith('https://dashboard.heroku.com/new-app')
       || destination.startsWith('#')
       || destination.startsWith('mailto:')
     return (

--- a/install/heroku_postgres/01_deploy_the_collector.mdx
+++ b/install/heroku_postgres/01_deploy_the_collector.mdx
@@ -11,7 +11,7 @@ import { collectorAppName } from "./util";
 export const APIKey = ({ apiKey }) => !!apiKey ? <React.Fragment> <code>{apiKey}</code></React.Fragment> : null;
 
 export const HerokuButton = ({ apiKey }) => {
-  let href = 'https://heroku.com/deploy?template=https://github.com/pganalyze/collector'
+  let href = 'https://dashboard.heroku.com/new-app?template=https://github.com/pganalyze/collector'
   if (apiKey) {
     href += `&env[PGA_API_KEY]=${apiKey}`
   }


### PR DESCRIPTION
The current deployment link is outdated and links to a blank state of the "new app" view in Heroku. See before and after.

| Before  | After |
| ------------- | ------------- |
| <img width="500" alt="Screenshot 2024-08-27 at 11 57 03 AM" src="https://github.com/user-attachments/assets/72830753-4747-4794-868a-3d1bf7bdbcd8">  | <img width="500" alt="Screenshot 2024-08-27 at 11 57 26 AM" src="https://github.com/user-attachments/assets/a8dbcb20-a715-45c0-bece-17b2851e9a17">  |
