### PR TITLE
Update EKS setup docs to include Pod Identity usage

### DIFF
--- a/install/amazon_rds/03_install_collector_eks.mdx
+++ b/install/amazon_rds/03_install_collector_eks.mdx
@@ -6,7 +6,31 @@ backlink_title: 'Installation Guide'
 ---
 
 import SetupIAMPolicy from './_03_setup_iam_policy.mdx';
+import TabPanel, {TabTextContent} from '../../components/TabPanel'
 import CreateIAMRoleEKSIRSA from './_03_create_iam_role_eks_irsa.mdx'
+import CreateIAMRoleEKSPodIdentity from './_03_create_iam_role_eks_pod_identity.mdx'
+
+export const EKSIAMRoleCreation = () => {
+  const tabs = [
+    [ 'podidentity', 'Pod Identity' ],
+    [ 'irsa', 'IAM roles for service accounts (IRSA)'],
+  ];
+  return (
+    <TabPanel items={tabs}>
+      {(idx) => {
+        const tab = tabs[idx][0];
+        switch (tab) {
+          case 'podidentity':
+            return <TabTextContent><CreateIAMRoleEKSPodIdentity /></TabTextContent>;
+          case 'irsa':
+            return <TabTextContent><CreateIAMRoleEKSIRSA /></TabTextContent>;
+          default:
+            return null;
+        }
+      }}
+    </TabPanel>
+  )
+}
 
 ## Installing the collector with Amazon EKS
 
@@ -23,11 +47,7 @@ You can install the Helm chart for the pganalyze collector on your [Amazon EKS c
 
 ### Create IAM role
 
-**Note:** Creating an IAM role currently requires using IAM roles for service
-accounts (IRSA). Creating an IAM role with Amazon EKS Pod Identity is not
-supported yet.
-
-<CreateIAMRoleEKSIRSA />
+<EKSIAMRoleCreation />
 
 <Link className="btn btn-success" to="04_configure_the_collector_eks">
   Proceed to Step 4: Configure the Collector

--- a/install/amazon_rds/04_configure_the_collector_eks.mdx
+++ b/install/amazon_rds/04_configure_the_collector_eks.mdx
@@ -29,7 +29,8 @@ helm show values pganalyze/pganalyze-collector > values.yaml
 
 Update the serviceAccount section in the values.yaml file to use the role just
 created in the previous step. For the name, use "pganalyze-service-account" as
-specified in the assume role policy:
+specified in the Pod Identity association (for Pod Identity) or the assume role
+policy (for IRSA):
 
 ```yaml
 serviceAccount:
@@ -37,6 +38,7 @@ serviceAccount:
   create: true
   # -- Annotations to add to the service account
   annotations:
+    # Add this annotation only if you're using IRSA (not required for Pod Identity)
     eks.amazonaws.com/role-arn: "arn:aws:iam::<aws-account-id>:role/pganalyzeServiceAccountRole"
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
@@ -149,7 +151,7 @@ helm repo add pganalyze https://charts.pganalyze.com/
 Then, install a chart, using the values.yaml file created earlier:
 
 ```
-helm upgrade --install my-collector pganalyze/pganalyze-collector --values=values.yml
+helm upgrade --install my-collector pganalyze/pganalyze-collector --values=values.yaml
 ```
 
 Adjust the namespace if needed. You can run the same command when you make a

--- a/install/amazon_rds/04_configure_the_collector_eks.mdx
+++ b/install/amazon_rds/04_configure_the_collector_eks.mdx
@@ -37,9 +37,10 @@ serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
   # -- Annotations to add to the service account
-  annotations:
-    # Add this annotation only if you're using IRSA (not required for Pod Identity)
-    eks.amazonaws.com/role-arn: "arn:aws:iam::<aws-account-id>:role/pganalyzeServiceAccountRole"
+  annotations: {}
+  # Update above annotation if you're using IRSA
+  # annotations:
+  #   eks.amazonaws.com/role-arn: "arn:aws:iam::<aws-account-id>:role/pganalyzeServiceAccountRole"
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: "pganalyze-service-account"

--- a/install/amazon_rds/_03_create_iam_role_eks_pod_identity.mdx
+++ b/install/amazon_rds/_03_create_iam_role_eks_pod_identity.mdx
@@ -2,6 +2,8 @@ With this step, you are going to create a new IAM role and associate that role
 with the service account using
 [Amazon EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
 
+**Note:** This requires the pganalyze collector version 0.58.0 and above.
+
 If you haven't installed Amazon EKS Pod Identity Agent add-on, install it with
 this command:
 
@@ -49,5 +51,5 @@ aws eks create-pod-identity-association \
   --cluster-name mycluster \
   --namespace default \
   --service-account pganalyze-service-account \
-  --role-arn arn:aws:iam::012345678901:role/pganalyzeServiceAccountRole
+  --role-arn arn:aws:iam::<aws-account-id>:role/pganalyzeServiceAccountRole
 ```


### PR DESCRIPTION
With a new collector, now people can use Pod Identity with EKS. I double checked and confirmed that this works with a new collector.
Revive the doc that I created previously to mention the Pod Identity way.

![image](https://github.com/user-attachments/assets/0bb4f198-6417-4dd5-af6a-9d22a2aecf78)
