### PR TITLE
Clarify how to monitor Aurora cluster with multiple readers

### DIFF
--- a/install/amazon_rds/04_configure_the_collector_docker.mdx
+++ b/install/amazon_rds/04_configure_the_collector_docker.mdx
@@ -47,9 +47,9 @@ Create a new configuration file (e.g. named `pganalyze_collector.replica.env`) a
 DB_HOST=mydbcluster.cluster-ro-123456789012.us-east-1.rds.amazonaws.com
 ```
 
-If you have multiple readers you want to monitor, you either need to add it to
-the content of `CONFIG_CONTENTS`, or run one pganalyze collector Docker
-container for each instance.
+If you have multiple readers with a cluster, you either need to add each instance
+endpoint to the content of `CONFIG_CONTENTS` (e.g. add each sections like `[reader_instance1]`, `[reader_instance2]`),
+or run one pganalyze collector Docker container for each instance.
 
 ## Test snapshot
 

--- a/install/amazon_rds/04_configure_the_collector_ec2.mdx
+++ b/install/amazon_rds/04_configure_the_collector_ec2.mdx
@@ -70,7 +70,7 @@ db_host = mydbcluster.cluster-ro-123456789012.us-east-1.rds.amazonaws.com
 For writer instances this is supported for any size of cluster, but for
 reader instances this is only supported in two-node clusters (i.e. single reader instance).
 
-If you have multiple readers you want to monitor you instead need to specify each instance endpoint separately:
+If you have multiple readers with a cluster, you instead need to specify each instance endpoint separately:
 
 ```
 [instance1]

--- a/install/amazon_rds/04_configure_the_collector_ecs.mdx
+++ b/install/amazon_rds/04_configure_the_collector_ecs.mdx
@@ -56,9 +56,10 @@ Use the `cluster-ro` endpoint as the `DB_HOST` of the environment variables:
 {"name": "DB_HOST", "value": "mydbcluster.cluster-ro-123456789012.us-east-1.rds.amazonaws.com"},
 ```
 
-If you have multiple readers you want to monitor, you either need to add it to
-the content of the `pganalyze_collector.conf` file, then update the `/pganalyze/CONFIG_CONTENTS`
-SSM secret, or run one pganalyze collector Docker container for each instance.
+If you have multiple readers with a cluster, you either need to add each instance
+endpoint to the content of the `pganalyze_collector.conf` file (e.g. add each section like `[reader_instance1]`, `[reader_instance2]`),
+then update the `/pganalyze/CONFIG_CONTENTS` SSM secret, or run one pganalyze
+collector Docker container for each instance.
 
 ## Registering the task and launching it
 

--- a/install/amazon_rds/04_configure_the_collector_eks.mdx
+++ b/install/amazon_rds/04_configure_the_collector_eks.mdx
@@ -137,9 +137,9 @@ Use the `cluster-ro` endpoint as the `DB_HOST` of the environment variables:
 DB_HOST: mydbcluster.cluster-ro-123456789012.us-east-1.rds.amazonaws.com
 ```
 
-If you have multiple readers you want to monitor, you either need to specify
-using `CONFIG_CONTENTS` environment variable, or install one pganalyze collector
-Helm chart for each instance.
+If you have multiple readers with a cluster, you either need to add each instance
+endpoint to the content of `CONFIG_CONTENTS` (e.g. add each sections like `[reader_instance1]`, `[reader_instance2]`),
+or install one pganalyze collector Helm chart for each instance.
 
 ## Install a Helm chart
 

--- a/log-insights/setup/heroku-postgres/toc.yml
+++ b/log-insights/setup/heroku-postgres/toc.yml
@@ -4,5 +4,5 @@
     href: log-insights/setup/heroku-postgres/01_add_log_drain
   - name: "Step 2: Verify Log Drain"
     href: log-insights/setup/heroku-postgres/02_verify_log_drain
-  - name: "Step 3: Restar Collector"
+  - name: "Step 3: Restart Collector"
     href: log-insights/setup/heroku-postgres/03_restart_collector


### PR DESCRIPTION
Maybe it's only me with my weird reading, but when you say "If you have multiple readers you want to monitor, do X", I feel like "well I don't need to monitor them all, let me skip reading/doing X" even though I have multiple readers with a cluster.
Actually, I was always wondering what these sentences actually means, and I didn't fully understand this until today. So I think it's the best to remove any ambiguity and clarify that monitoring them individually is necessary (IOW, using  for Aurora cluster with multiple readers.

Actually, just noticed that EC2 doc does say "this is only supported in two-node clusters (i.e. single reader instance)" for `cluster-ro` way, which is really clear. We could adopt this to other docs too 🤔 