### PR TITLE
Update get_column_stats for Postgres 17

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -41,7 +41,7 @@ CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats A
 $$
   /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
     n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
-    most_common_elem_freqs, elem_count_histogram
+    most_common_elem_freqs, elem_count_histogram, range_length_histogram, range_empty_frac, NULL::anyarray
   FROM pg_catalog.pg_stats
   WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
@@ -90,7 +90,7 @@ CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats A
 $$
   /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
     n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
-    most_common_elem_freqs, elem_count_histogram
+    most_common_elem_freqs, elem_count_histogram, range_length_histogram, range_empty_frac, NULL::anyarray
   FROM pg_catalog.pg_stats
   WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}

--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -37,11 +37,11 @@ export const MonitoringUserPerDatabaseHelpers: React.FunctionComponent<{ usernam
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
 
-CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
-$$
-  /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
-    n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
-    most_common_elem_freqs, elem_count_histogram, range_length_histogram, range_empty_frac, NULL::anyarray
+CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
+  schemaname name, tablename name, attname name, inherited bool, null_frac real, avg_width int, n_distinct real, correlation real
+) AS $$
+  /* pganalyze-collector */
+  SELECT schemaname, tablename, attname, inherited, null_frac, avg_width, n_distinct, correlation
   FROM pg_catalog.pg_stats
   WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
@@ -86,11 +86,11 @@ export const MonitoringUserColumnStats: React.FunctionComponent<{ username: stri
       <CodeBlock>
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
-CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
-$$
-  /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
-    n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
-    most_common_elem_freqs, elem_count_histogram, range_length_histogram, range_empty_frac, NULL::anyarray
+CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
+  schemaname name, tablename name, attname name, inherited bool, null_frac real, avg_width int, n_distinct real, correlation real
+) AS $$
+  /* pganalyze-collector */
+  SELECT schemaname, tablename, attname, inherited, null_frac, avg_width, n_distinct, correlation
   FROM pg_catalog.pg_stats
   WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}


### PR DESCRIPTION
On Postgres 17, the function breaks:

```sql
select * from pganalyze.get_column_stats() limit 1;
ERROR:  return type mismatch in function declared to return pg_stats
DETAIL:  Final statement returns too few columns.
CONTEXT:  SQL function "get_column_stats" during startup
```

Note that this documentation update makes it so this function definition no longer works for previous versions of Postgres. Do we have a UI pattern to handle this, like a tabbed component that lets you switch between PG 16 and 17 versions of the function?

This error wouldn't have occurred if the function didn't `RETURNS SETOF pg_stats`, instead choosing to return its own row type. If we don't plan to use the new fields, maybe we should change the return type instead of adding the new fields?

Here's the documentation for the new fields. IIRC this function is intended to return all data points that are not considered sensitive (don't include user data), so I've chosen to return null for `range_bounds_histogram`

![Screenshot 2024-10-09 at 11 05 37 AM](https://github.com/user-attachments/assets/ff606e36-43b9-4843-8ccb-b647dc0f0365)

