### PR TITLE
Update helper setup to use DROP FUNCTION IF EXISTS

### DIFF
--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -37,7 +37,8 @@ export const MonitoringUserPerDatabaseHelpers: React.FunctionComponent<{ usernam
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
 
-CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
+DROP FUNCTION IF EXISTS pganalyze.get_column_stats;
+CREATE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
   schemaname name, tablename name, attname name, inherited bool, null_frac real, avg_width int, n_distinct real, correlation real
 ) AS $$
   /* pganalyze-collector */
@@ -46,7 +47,8 @@ CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
   WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 
-CREATE OR REPLACE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
+DROP FUNCTION IF EXISTS pganalyze.get_relation_stats_ext;
+CREATE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
   statistics_schemaname text, statistics_name text,
   inherited boolean, n_distinct pg_ndistinct, dependencies pg_dependencies,
   most_common_val_nulls boolean[], most_common_freqs float8[], most_common_base_freqs float8[]
@@ -86,7 +88,8 @@ export const MonitoringUserColumnStats: React.FunctionComponent<{ username: stri
       <CodeBlock>
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
-CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
+DROP FUNCTION IF EXISTS pganalyze.get_column_stats;
+CREATE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
   schemaname name, tablename name, attname name, inherited bool, null_frac real, avg_width int, n_distinct real, correlation real
 ) AS $$
   /* pganalyze-collector */
@@ -120,7 +123,8 @@ export const MonitoringUserExtStats: React.FunctionComponent<{ username: string,
       <CodeBlock>
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
-CREATE OR REPLACE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
+DROP FUNCTION IF EXISTS pganalyze.get_relation_stats_ext;
+CREATE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
   statistics_schemaname text, statistics_name text,
   inherited boolean, n_distinct pg_ndistinct, dependencies pg_dependencies,
   most_common_val_nulls boolean[], most_common_freqs float8[], most_common_base_freqs float8[]


### PR DESCRIPTION
If the return type of a function changes, `CREATE OR REPLACE FUNCTION` will fail with `ERROR: cannot change return type of existing function`. To make function setup more foolproof, this PR updates the documentation to instead use `DROP FUNCTION IF EXISTS`.

Note that I've only updated `get_column_stats` and `get_relation_stats_ext` since they return a subset of columns, while `get_stat_replication` for example does `SELECT *`, so shouldn't be affected when Postgres adds new columns in the future.