### PR TITLE
Fix Google Cloud settings labeling

### DIFF
--- a/collector/settings.mdx
+++ b/collector/settings.mdx
@@ -458,17 +458,17 @@ Only relevant if you are running your database in GCP using Google Cloud SQL or 
   <tbody>
     <tr>
       <td>gcp_cloudsql_instance_id (<code>GCP_CLOUDSQL_INSTANCE_ID</code>)</td>
-      <td>n/a, required for Log Insights (for Cloud SQL)</td>
+      <td>n/a, required (for Cloud SQL)</td>
       <td>Google Cloud SQL instance ID</td>
     </tr>
     <tr>
       <td>gcp_alloydb_cluster_id (<code>GCP_ALLOYDB_CLUSTER_ID</code>)</td>
-      <td>n/a, required for Log Insights (for AlloyDB)</td>
+      <td>n/a, required (for AlloyDB)</td>
       <td>Google AlloyDB cluster ID</td>
     </tr>
     <tr>
       <td>gcp_alloydb_instance_id (<code>GCP_ALLOYDB_INSTANCE_ID</code>)</td>
-      <td>n/a, required for Log Insights (for AlloyDB)</td>
+      <td>n/a, required (for AlloyDB)</td>
       <td>Google AlloyDB instance ID (within the given cluster)</td>
     </tr>
     <tr>


### PR DESCRIPTION
The cluster / instance ID settings are generally required, not just
required for Log Insights.
