### PR TITLE
Add a pganalyze repo first before helm show values

### DIFF
--- a/install/amazon_rds/04_configure_the_collector_eks.mdx
+++ b/install/amazon_rds/04_configure_the_collector_eks.mdx
@@ -21,9 +21,12 @@ export const FinishSetup = ({ inviteLink }) => {
 
 ## Configuring the collector on Amazon EKS
 
-To start, download the example values.yaml file for the Helm chart:
+To start, download an example values.yaml file for the Helm chart:
 
 ```
+# Add a pganalyze repo:
+helm repo add pganalyze https://charts.pganalyze.com/
+# Download an example values.yaml file:
 helm show values pganalyze/pganalyze-collector > values.yaml
 ```
 
@@ -143,7 +146,8 @@ or install one pganalyze collector Helm chart for each instance.
 
 ## Install a Helm chart
 
-We can now install a Helm chart to your EKS cluster. First, add a pganalyze repo:
+We can now install a Helm chart to your EKS cluster. First, add a pganalyze repo
+if you already haven't added in the previous step:
 
 ```
 helm repo add pganalyze https://charts.pganalyze.com/


### PR DESCRIPTION
`helm show values pganalyze/pganalyze-collector` will fail with "repo pganalyze not found" if `helm repo add pganalyze https://charts.pganalyze.com/` hasn't run already.
Make sure to add that to the step before running `helm show values`.