### PR TITLE
Update IAM policy link to access from the app

### DIFF
--- a/api/index.mdx
+++ b/api/index.mdx
@@ -26,6 +26,7 @@ change pganalyze settings.
 
 - [Creating an API key](/docs/api/create-api-key)
 - [Queries](/docs/api/queries)
+    * [getServers - Get a list of servers for an organization](/docs/api/queries/getServers)
     * [getIssues - Get check-up issues and alerts](/docs/api/queries/getIssues)
     * [getQueryStats - Export query statistics](/docs/api/queries/getQueryStats)
 - [Mutations](/docs/api/mutations)

--- a/install/amazon_rds/_03_setup_iam_policy.mdx
+++ b/install/amazon_rds/_03_setup_iam_policy.mdx
@@ -37,4 +37,4 @@ This policy grants the following access:
 - Cloudwatch metrics to show CPU utilization and other system metrics in pganalyze
 - RDS log file download (for [pganalyze Log Insights](https://pganalyze.com/log-insights))
 
-To learn more about each access, see [Amazon RDS and Aurora: IAM Policy](/docs/install/amazon_rds/iam_policy).
+To learn more about each access, see [Amazon RDS and Aurora: IAM Policy](https://pganalyze.com/docs/install/amazon_rds/iam_policy).

--- a/log-insights/setup/amazon-rds/01_test_log_download.mdx
+++ b/log-insights/setup/amazon-rds/01_test_log_download.mdx
@@ -32,7 +32,7 @@ The collector will start sending logs shortly.
   </p>
 </PublicOnly>
 
-In case you get permission errors, make sure your IAM user has the [appropriate policy associated](/docs/install/amazon_rds/iam_policy).
+In case you get permission errors, make sure your IAM user has the [appropriate policy associated](https://pganalyze.com/docs/install/amazon_rds/iam_policy).
 
 <PublicOnly>
   <p>You will then see Log Insights data on your database within a few minutes:</p>


### PR DESCRIPTION
These two docs can be rendered within the app, and without the absolute path, the link will be broken (or rather, page won't be loaded).
Update the link to the full path so that it can be opened as a docs page in the separate window when accessed from the app.