### PR TITLE
ECS task JSON fixes

### DIFF
--- a/install/amazon_rds/_04_setting_env_vars_single_ecs.mdx
+++ b/install/amazon_rds/_04_setting_env_vars_single_ecs.mdx
@@ -52,7 +52,7 @@ Now, save the following ECS task definition to a file, for example `pganalyze_ta
       "environment": [
         {"name": "DB_HOST", "value": "your_database_host"},
         {"name": "DB_USERNAME", "value": "your_monitoring_user"},
-        {"name": "DB_NAME", "value": "your_database_name"},
+        {"name": "DB_NAME", "value": "your_database_name"}
       ],
       "secrets": [
         {"name": "PGA_API_KEY", "valueFrom": "/pganalyze/PGA_API_KEY"},
@@ -66,7 +66,6 @@ Now, save the following ECS task definition to a file, for example `pganalyze_ta
           "awslogs-stream-prefix": "pganalyze"
         }
       },
-      "user": 1000,
       "readonlyRootFilesystem": false,
       "mountPoints": []
     }


### PR DESCRIPTION
As noted by a user:
- the trailing comma isn't valid in JSON
- `user` must be a string, but it's not a required field so I've removed it