### PR TITLE
Fix query tuning helper

### DIFF
--- a/components/helperSQL.ts
+++ b/components/helperSQL.ts
@@ -14,7 +14,7 @@ BEGIN
     RAISE EXCEPTION 'cannot run: pganalyze.explain_analyze helper is owned by superuser - recreate function with lesser privileged user';
   END IF;
 
-  SELECT pg_catalog.regexp_replace(query, ';+\s*\Z', '') INTO prepared_query;
+  SELECT pg_catalog.regexp_replace(query, ';+\\s*\\Z', '') INTO prepared_query;
   IF prepared_query LIKE '%;%' THEN
     RAISE EXCEPTION 'cannot run pganalyze.explain_analyze helper with a multi-statement query';
   END IF;


### PR DESCRIPTION
The backslashes in the regexp we use must be escaped for JavaScript.
