### PR TITLE
Update the separator from : to =

### DIFF
--- a/log-insights/setup/self-managed/02_configure_collector.mdx
+++ b/log-insights/setup/self-managed/02_configure_collector.mdx
@@ -13,7 +13,7 @@ We can now configure the log directory for the collector, by adding the `db_log_
 similar to this:
 
 ```
-db_log_location: [log location discovered in Step 1]
+db_log_location = [log location discovered in Step 1]
 ```
 
 Then, use the `--test-logs` option of the collector to verify that log collection and parsing works:


### PR DESCRIPTION
Reported by the customer - we're using `=` elsewhere and also `=` is a standard format of INI config files, so let's update here.