### PR TITLE
Remove Cosmos DB from the title, add note about Cosmos DB

### DIFF
--- a/_install_choice.mdx
+++ b/_install_choice.mdx
@@ -25,7 +25,7 @@ export const InstallChoiceList = ({ docsRoot }) => {
           link: "install/azure_database/01_configure_azure_instance",
           img: imgLogoAzure,
           providerName: "Microsoft Azure",
-          text: "Flexible Server and Cosmos DB",
+          text: "Flexible Server",
         },
         {
           link: "install/google_cloud_sql/01_create_monitoring_user",

--- a/install/azure_database/01_configure_azure_instance.mdx
+++ b/install/azure_database/01_configure_azure_instance.mdx
@@ -17,7 +17,7 @@ extension for collecting query statistics.
 This guide assumes you have an already running Azure Database for PostgreSQL flexible server you want to monitor.
 
 For Azure Cosmos DB for PostgreSQL Cluster, this step is not required as pg_stat_statements is already preloaded.
-While the pganalyze collector supports collecting data from Azure Cosmos DB for PostgreSQL, this integration is not officially supported at this time.
+While the pganalyze collector supports collecting data from Azure Cosmos DB for PostgreSQL, this integration is no longer officially supported.
 This means that while data collection may work, we cannot guarantee full compatibility, and certain features may not function as expected.
 
 ---

--- a/install/azure_database/01_configure_azure_instance.mdx
+++ b/install/azure_database/01_configure_azure_instance.mdx
@@ -15,7 +15,10 @@ to first follow these steps to enable the [pg_stat_statements](http://www.postgr
 extension for collecting query statistics.
 
 This guide assumes you have an already running Azure Database for PostgreSQL flexible server you want to monitor.
+
 For Azure Cosmos DB for PostgreSQL Cluster, this step is not required as pg_stat_statements is already preloaded.
+While the pganalyze collector supports collecting data from Azure Cosmos DB for PostgreSQL, this integration is not officially supported at this time.
+This means that while data collection may work, we cannot guarantee full compatibility, and certain features may not function as expected.
 
 ---
 

--- a/install/toc.yml
+++ b/install/toc.yml
@@ -16,7 +16,7 @@
     href: install/amazon_rds
   - name: Google Cloud SQL and AlloyDB
     href: install/google_cloud_sql
-  - name: Azure Database for PostgreSQL and CosmosDB
+  - name: Azure Database for PostgreSQL
     href: install/azure_database
   - name: Crunchy Bridge
     href: install/crunchy_bridge


### PR DESCRIPTION
As discussed internally, remove this from the officially supported list. I still kept some special tweaks note for Cosmos DB in the installation guide docs, but I added some caution in the beginning of the guide.