### PR TITLE
Update Crunchy Bridge instruction to support new logging

### DIFF
--- a/install/crunchy_bridge/01_deploy_the_collector.mdx
+++ b/install/crunchy_bridge/01_deploy_the_collector.mdx
@@ -11,7 +11,7 @@ import { MonitoringUserLogRead, MonitoringUserPerDatabaseHelpers } from "../../c
 export const CollectorStartCommand = ({ apiKey, cmd, logExplain }) => {
   return (
     <CodeBlock>
-      {`SELECT run_container('` + (cmd ? '' : '-d ') + `-t -e DB_URL="REPLACE_ME" -e PGA_API_KEY="` + (apiKey ? apiKey : 'API_KEY') + '"' + (logExplain ? ' -e PGA_ENABLE_LOG_EXPLAIN=true' : '') + ` -e CRUNCHY_BRIDGE_API_KEY="REPLACE_ME" -e DB_ALL_NAMES=1 quay.io/pganalyze/collector:stable` + (cmd ? ` ${cmd}` : '') + `');`}
+      {`SELECT run_container('` + (cmd ? '' : '-d ') + `-t -e DB_URL="REPLACE_ME" -e PGA_API_KEY="` + (apiKey ? apiKey : 'API_KEY') + '"' + (logExplain ? ' -e PGA_ENABLE_LOG_EXPLAIN=true' : '') + ` -e CRUNCHY_BRIDGE_API_KEY="REPLACE_ME" -e DB_ALL_NAMES=1 --privileged quay.io/pganalyze/collector:stable` + (cmd ? ` ${cmd}` : '') + `');`}
     </CodeBlock>
   );
 };
@@ -29,11 +29,7 @@ To ensure the application user can access monitoring statistics for all users (n
 GRANT pg_monitor TO application;
 ```
 
-Additionally, run the following to allow the application user to read the Postgres server log:
-
-<MonitoringUserLogRead username="application" />
-
-<MonitoringUserPerDatabaseHelpers username="pganalyze" />
+<MonitoringUserPerDatabaseHelpers username="application" />
 
 In later steps you can now specify the application user credentials as the `DB_URL`.
 
@@ -53,31 +49,29 @@ See the [Crunchy Bridge documentation](https://docs.crunchybridge.com/api-concep
 
 ## Run collector test
 
-Run the following command to verify the configuration. For the `DB_URL`, specify the application user credentials.
+Run the following command to verify the configuration. For the `DB_URL`, specify the database URL to monitor.
 For the `CRUNCHY_BRIDGE_API_KEY`, specify the API key created above.
+Before running this command, you can run `\t \a` to show the result in a better format.
 
 <CollectorStartCommand apiKey={props.apiKey} cmd="test" />
 
 This should return output like this:
 
 ```
-                                run_container
---------------------------------------------------------------------------------
- I Running collector test with pganalyze-collector X.XX.X
- I [default] Testing statistics collection...
- I [default]   Test collection successful for PostgreSQL XX.X
- I [default]   Test snapshot successful (27.9 KB)
- I [default] Testing activity snapshots...
- I [default]   Test snapshot successful (2.28 KB)
- I [default] Testing log download...
- I [default]   Test snapshot successful (1.45 KB)
- I [default]   Log test successful
+I Running collector test with pganalyze-collector X.XX.X
+I [default] Testing statistics collection...
+I [default]   Test collection successful for PostgreSQL XX.X
+I [default] Submitted full snapshot successfully
+I [default] Testing activity snapshots...
+I [default] Testing log download...
+E [default] ERROR - Could not download logs: could not collect logs: LogReadSql/QueryRow: pq: permission denied for function pg_read_file
 
- Test successful. View servers in pganalyze:
-  - [default]: https://app.pganalyze.com/servers/SERVER_ID
+...Test summary
 
-(1 row)
+Test successful
 ```
+
+Note that Log Insights will show error until you complete the setup step of [Log Insights](/docs/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test).
 
 ## Start collector in the background
 

--- a/install/crunchy_bridge/01_deploy_the_collector.mdx
+++ b/install/crunchy_bridge/01_deploy_the_collector.mdx
@@ -23,7 +23,7 @@ In order to monitor a Crunchy Bridge database you run the pganalyze collector di
 
 We recommend using a role with limited privileges for monitoring. You can use Crunchy Bridge's application user as the user for monitoring, or create a separate role. The instructions here assume you are using the application user.
 
-To ensure the application user can access monitoring statistics for all users (not just itself), and can read the server log, **run the following with the superuser credentials**:
+To ensure the application user can access monitoring statistics for all users (not just itself), and can read the server log, **run the following with superuser credentials**:
 
 ```sql
 GRANT pg_monitor TO application;

--- a/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test.mdx
+++ b/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test.mdx
@@ -15,7 +15,7 @@ export const ImgLogInsightsScreenshot = () => <img src={imgLogInsightsScreenshot
 
 Log output for Crunchy Bridge database servers is collected directly from the database server using SQL functions.
 
-If you are using the application user, an additional function needs to be created to grant access to the logs (**run the following with the superuser credentials**):
+If you are using the application user, an additional function needs to be created to grant access to the logs (**run the following with superuser credentials**):
 
 <MonitoringUserLogRead username="application" />
 

--- a/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test.mdx
+++ b/log-insights/setup/crunchy-bridge/01_create_helper_function_and_test.mdx
@@ -15,9 +15,14 @@ export const ImgLogInsightsScreenshot = () => <img src={imgLogInsightsScreenshot
 
 Log output for Crunchy Bridge database servers is collected directly from the database server using SQL functions.
 
-If you are using the application user, an additional function needs to be created to grant access to the logs:
+If you are using the application user, an additional function needs to be created to grant access to the logs (**run the following with the superuser credentials**):
 
 <MonitoringUserLogRead username="application" />
+
+Next, configure your cluster to enable file logging by adding config parameters using the dashboard with these values:
+
+* **log_destination**: `syslog,stderr`
+* **log_line_prefix**: `'%m [%p] %q[user=%u,db=%d,app=%a] '`
 
 You can then verify whether this is working by running the test command:
 
@@ -26,22 +31,17 @@ You can then verify whether this is working by running the test command:
 This should show an output like this:
 
 ```
-                                run_container
---------------------------------------------------------------------------------
- I Running collector test with pganalyze-collector X.XX.X
- I [default] Testing statistics collection...
- I [default]   Test collection successful for PostgreSQL XX.X
- I [default]   Test snapshot successful (27.9 KB)
- I [default] Testing activity snapshots...
- I [default]   Test snapshot successful (2.28 KB)
- I [default] Testing log download...
- I [default]   Test snapshot successful (1.45 KB)
- I [default]   Log test successful
+I Running collector test with pganalyze-collector X.XX.X
+I [default] Testing statistics collection...
+I [default]   Test collection successful for PostgreSQL XX.X
+I [default] Submitted full snapshot successfully
+I [default] Testing activity snapshots...
+I [default] Testing log download...
+I [default]   Log test successful
 
- Test successful. View servers in pganalyze:
-  - [default]: https://app.pganalyze.com/servers/SERVER_ID
+...Test summary
 
-(1 row)
+Test successful
 ```
 
 Note the "Log test successful", which indicates that the helper method works correctly.


### PR DESCRIPTION
Using https://docs.crunchybridge.com/container-apps/pganalyze-quickstart as a reference.
Currently, Log Insights is unable to set up unless the user follows above. Two main things:

* They need to specify `log_destination` setting in the config
* `--privileged` needs to be added to the podman command

I also updated the test output log part a bit, and mention that the user can do `\t \a` to get better logs (otherwise, they get pretty terribly formatted logs like `\x1B[92m✓\x1B[0m Database connection:   ok\r`).