### PR TITLE
Add Important Fields to Function Scan node

### DIFF
--- a/explain/scan-nodes/function-scan.mdx
+++ b/explain/scan-nodes/function-scan.mdx
@@ -1,7 +1,7 @@
 ---
 plan_node: Function Scan
 short_description: Scans the result of a set-returning function (like unnest or regexp_split_to_table).
-important_fields: Function Name
+important_fields: Function Name, Function Call, Filter, Rows Removed by Filter
 title: EXPLAIN - Function Scan
 backlink_href: /docs/explain/scan-nodes
 backlink_title: 'Documentation: EXPLAIN - Scan Nodes'


### PR DESCRIPTION
Missed in aa025a5e6006b944699046d09a37105d7807b067. That commit added
some fields to the list, but did not add them to the frontmatter
metadata that is used to show this field data in some EXPLAIN views.
