### PR TITLE
Retitle Log Insights events

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -1102,7 +1102,7 @@
       "hasAnalysis": null
     },
     "A61": {
-      "title": "Database must be vacuumed within N transactions (TXID Wraparound Warning)",
+      "title": "TXID wraparound warning",
       "category": "autovacuum",
       "collectorKey": "TXID_WRAPAROUND_WARNING",
       "tooltip": "Database is at risk of forced shutdown due to overdue VACUUM",
@@ -1113,7 +1113,7 @@
       "hasAnalysis": null
     },
     "A62": {
-      "title": "Database is not accepting commands to avoid wraparound data loss",
+      "title": "TXID wraparound critical",
       "category": "autovacuum",
       "collectorKey": "TXID_WRAPAROUND_ERROR",
       "tooltip": "The database has been interrupted due to imminent TXID wraparound - manual intervention required",
@@ -1135,7 +1135,7 @@
       "hasAnalysis": null
     },
     "A64": {
-      "title": "Autovacuum launcher shutting down",
+      "title": "Autovacuum launcher stopped",
       "category": "autovacuum",
       "collectorKey": "AUTOVACUUM_LAUNCHER_SHUTTING_DOWN",
       "tooltip": "The autovacuum launcher has been stopped",
@@ -1146,7 +1146,7 @@
       "hasAnalysis": null
     },
     "A65": {
-      "title": "Automatic vacuum of table completed",
+      "title": "Autovacuum completed",
       "category": "autovacuum",
       "collectorKey": "AUTOVACUUM_COMPLETED",
       "tooltip": "Automatic VACUUM for the referenced table has completed",
@@ -1157,7 +1157,7 @@
       "hasAnalysis": null
     },
     "A66": {
-      "title": "Automatic analyze of table completed",
+      "title": "Autoanalyze completed",
       "category": "autovacuum",
       "collectorKey": "AUTOANALYZE_COMPLETED",
       "tooltip": "Automatic ANALYZE for the referenced table has completed",
@@ -1168,7 +1168,7 @@
       "hasAnalysis": null
     },
     "A67": {
-      "title": "Skipping vacuum - lock not available",
+      "title": "Skipping vacuum due to lock",
       "category": "autovacuum",
       "collectorKey": "SKIPPING_VACUUM_LOCK_NOT_AVAILABLE",
       "tooltip": "Vacuum could not be started due to lock failure",
@@ -1179,7 +1179,7 @@
       "hasAnalysis": null
     },
     "A68": {
-      "title": "Skipping analyze - lock not available",
+      "title": "Skipping analyze due to lock",
       "category": "autovacuum",
       "collectorKey": "SKIPPING_ANALYZE_LOCK_NOT_AVAILABLE",
       "tooltip": "Vacuum could not be started due to lock failure",
@@ -1190,7 +1190,7 @@
       "hasAnalysis": null
     },
     "B90": {
-      "title": "Restored log file from archive (WAL replay)",
+      "title": "Replayed WAL file from archive",
       "category": "standby",
       "collectorKey": "STANDBY_RESTORED_WAL_FROM_ARCHIVE",
       "tooltip": "Postgres has replayed a WAL file from the archive using restore_command",
@@ -1201,7 +1201,7 @@
       "hasAnalysis": null
     },
     "B91": {
-      "title": "Started streaming WAL from primary",
+      "title": "Streaming WAL from primary",
       "category": "standby",
       "collectorKey": "STANDBY_STARTED_STREAMING",
       "tooltip": "Streaming replication has successfully started/resumed",
@@ -1212,7 +1212,7 @@
       "hasAnalysis": null
     },
     "B92": {
-      "title": "Could not receive data from WAL stream",
+      "title": "Could not receive WAL data",
       "category": "standby",
       "collectorKey": "STANDBY_STREAMING_INTERRUPTED",
       "tooltip": "Streaming replication was interrupted due to a network issue",
@@ -1223,7 +1223,7 @@
       "hasAnalysis": null
     },
     "B93": {
-      "title": "Terminating walreceiver process due to administrator command",
+      "title": "Terminating walreceiver",
       "category": "standby",
       "collectorKey": "STANDBY_STOPPED_STREAMING",
       "tooltip": "Streaming replication has stopped due to intervention",
@@ -1245,7 +1245,7 @@
       "hasAnalysis": null
     },
     "B95": {
-      "title": "Canceling statement due to conflict with recovery",
+      "title": "Canceling statement due to recovery conflict",
       "category": "standby",
       "collectorKey": "STANDBY_STATEMENT_CANCELED",
       "tooltip": "Statement tried to access data that is about to be removed",
@@ -1278,7 +1278,7 @@
       "hasAnalysis": null
     },
     "C22": {
-      "title": "Authentication failed / pg_hba.conf rejects connection",
+      "title": "Authentication failed",
       "category": "connections",
       "collectorKey": "CONNECTION_REJECTED",
       "tooltip": "New connection was rejected due to authentication/authorization errors",
@@ -1300,7 +1300,7 @@
       "hasAnalysis": null
     },
     "C24": {
-      "title": "Incomplete startup packet (client failed to connect)",
+      "title": "Client failed to connect",
       "category": "connections",
       "collectorKey": "CONNECTION_CLIENT_FAILED_TO_CONNECT",
       "tooltip": "The client opened a connection but didn't complete the initial process",
@@ -1311,7 +1311,7 @@
       "hasAnalysis": null
     },
     "C25": {
-      "title": "Could not receive data from client / connection to client lost",
+      "title": "Connection to client lost",
       "category": "connections",
       "collectorKey": "CONNECTION_LOST",
       "tooltip": "Network connection to the client was interrupted",
@@ -1322,7 +1322,7 @@
       "hasAnalysis": null
     },
     "C26": {
-      "title": "EOF on client connection with an open transaction",
+      "title": "Connection with open transaction lost",
       "category": "connections",
       "collectorKey": "CONNECTION_LOST_OPEN_TX",
       "tooltip": "Network interruption to client with an open transaction",
@@ -1333,7 +1333,7 @@
       "hasAnalysis": null
     },
     "C27": {
-      "title": "Terminating connection due to administrator command",
+      "title": "Terminating connection",
       "category": "connections",
       "collectorKey": "CONNECTION_TERMINATED",
       "tooltip": "This connection was terminated by a DBA / operator",
@@ -1344,7 +1344,7 @@
       "hasAnalysis": null
     },
     "C28": {
-      "title": "Remaining connection slots are reserved for superuser (out of connections)",
+      "title": "Too many connections",
       "category": "connections",
       "collectorKey": "OUT_OF_CONNECTIONS",
       "tooltip": "The number of connections has exceeded the max_connections setting",
@@ -1410,7 +1410,7 @@
       "hasAnalysis": null
     },
     "L70": {
-      "title": "Process acquired lock on tuple / relation / object",
+      "title": "Process acquired lock",
       "category": "locks",
       "collectorKey": "LOCK_ACQUIRED",
       "tooltip": "Lock was successfully acquired after exceeding deadlock_timeout",
@@ -1421,7 +1421,7 @@
       "hasAnalysis": null
     },
     "L71": {
-      "title": "Process still waiting for lock on tuple / relation / object",
+      "title": "Process still waiting for lock",
       "category": "locks",
       "collectorKey": "LOCK_WAITING",
       "tooltip": "Lock has not been acquired yet after waiting for deadlock_timeout",
@@ -1443,7 +1443,7 @@
       "hasAnalysis": null
     },
     "L73": {
-      "title": "Deadlock detected (transaction rolled back)",
+      "title": "Deadlock detected",
       "category": "locks",
       "collectorKey": "LOCK_DEADLOCK_DETECTED",
       "tooltip": "Deadlock between two connections was found and resolved by transaction cancellation",
@@ -1454,7 +1454,7 @@
       "hasAnalysis": null
     },
     "L74": {
-      "title": "Process avoided deadlock by rearranging queue order",
+      "title": "Process avoided deadlock",
       "category": "locks",
       "collectorKey": "LOCK_DEADLOCK_AVOIDED",
       "tooltip": "Deadlock between two connections was found and resolved by lock wait queue reordering",
@@ -1465,7 +1465,7 @@
       "hasAnalysis": null
     },
     "S1": {
-      "title": "Server process was terminated / Terminating connection because of crash",
+      "title": "Server process was terminated",
       "category": "server",
       "collectorKey": "SERVER_CRASHED",
       "tooltip": "Postgres server processes have crashed, server will be restarted",
@@ -1476,7 +1476,7 @@
       "hasAnalysis": null
     },
     "S10": {
-      "title": "Worker process exited / terminated by signal",
+      "title": "Worker process exited",
       "category": "server",
       "collectorKey": "SERVER_PROCESS_EXITED",
       "tooltip": "Internal process has exited - check exit code/signal",
@@ -1509,7 +1509,7 @@
       "hasAnalysis": null
     },
     "S3": {
-      "title": "Database system was interrupted (server starting)",
+      "title": "Database system was interrupted",
       "category": "server",
       "collectorKey": "SERVER_START_RECOVERING",
       "tooltip": "Postgres has restarted after a crash/forceful shutdown",
@@ -1542,7 +1542,7 @@
       "hasAnalysis": null
     },
     "S6": {
-      "title": "Invalid page / page verification failed (data corrupted)",
+      "title": "Data corrupted",
       "category": "server",
       "collectorKey": "SERVER_INVALID_CHECKSUM",
       "tooltip": "Failed to access table or index data due to corruption",
@@ -1553,7 +1553,7 @@
       "hasAnalysis": null
     },
     "S7": {
-      "title": "Temporary file: path ..., size ... (temp file created)",
+      "title": "Temp file created",
       "category": "server",
       "collectorKey": "SERVER_TEMP_FILE_CREATED",
       "tooltip": "Sorting/hashing operation was done through a file instead of in memory",
@@ -1597,7 +1597,7 @@
       "hasAnalysis": null
     },
     "T81": {
-      "title": "Canceling statement due to statement timeout",
+      "title": "Canceling statement due to timeout",
       "category": "statements",
       "collectorKey": "STATEMENT_CANCELED_TIMEOUT",
       "tooltip": "Statement was canceled since it ran longer than statement_timeout",
@@ -1608,7 +1608,7 @@
       "hasAnalysis": null
     },
     "T82": {
-      "title": "Canceling statement due to user request",
+      "title": "Canceling statement due to request",
       "category": "statements",
       "collectorKey": "STATEMENT_CANCELED_USER",
       "tooltip": "Statement was canceled due to operator calling pg_cancel_backend",
@@ -1696,7 +1696,7 @@
       "hasAnalysis": null
     },
     "U115": {
-      "title": "Subquery in FROM must have an alias",
+      "title": "Subquery in FROM must have alias",
       "category": "app-errors",
       "collectorKey": "SUBQUERY_MISSING_ALIAS",
       "tooltip": "The query is missing an alias name for a subquery",
@@ -1707,7 +1707,7 @@
       "hasAnalysis": null
     },
     "U116": {
-      "title": "INSERT has more expressions than target columns",
+      "title": "INSERT does not match target columns",
       "category": "app-errors",
       "collectorKey": "INSERT_TARGET_COLUMN_MISMATCH",
       "tooltip": "The # of columns in your INSERT statements are different than the # of values per row",
@@ -1806,7 +1806,7 @@
       "hasAnalysis": null
     },
     "U125": {
-      "title": "No unique or exclusion constraint matching the ON CONFLICT specification",
+      "title": "Unmatched ON CONFLICT specification",
       "category": "app-errors",
       "collectorKey": "ON_CONFLICT_NO_CONSTRAINT_MATCH",
       "tooltip": "Missing unique/exclusion constraint for conflict resolution in ON CONFLICT statement",
@@ -1817,7 +1817,7 @@
       "hasAnalysis": null
     },
     "U126": {
-      "title": "ON CONFLICT DO UPDATE command cannot affect row a second time",
+      "title": "ON CONFLICT DO UPDATE affected row twice",
       "category": "app-errors",
       "collectorKey": "ON_CONFLICT_ROW_AFFECTED_TWICE",
       "tooltip": "INSERT statement contains the same row twice, as determined by ON CONFLICT constraint",
@@ -1850,7 +1850,7 @@
       "hasAnalysis": null
     },
     "U129": {
-      "title": "Cannot drop table / Cannot drop object",
+      "title": "Cannot drop object",
       "category": "app-errors",
       "collectorKey": "CANNOT_DROP",
       "tooltip": "The statement failed to drop the referenced object",
@@ -1883,7 +1883,7 @@
       "hasAnalysis": null
     },
     "U132": {
-      "title": "There is no parameter $1 / $n",
+      "title": "There is no parameter $n",
       "category": "app-errors",
       "collectorKey": "PARAM_MISSING",
       "tooltip": "The referenced parameter $n is missing",
@@ -1949,7 +1949,7 @@
       "hasAnalysis": null
     },
     "U138": {
-      "title": "Could not serialize access due to concurrent update",
+      "title": "Could not serialize access: concurrent update",
       "category": "app-errors",
       "collectorKey": "COULD_NOT_SERIALIZE_REPEATABLE_READ",
       "tooltip": "UPDATE or DELETE was run concurrently on the same row with isolation level REPEATABLE READ",
@@ -1960,7 +1960,7 @@
       "hasAnalysis": null
     },
     "U139": {
-      "title": "Could not serialize access due to read/write dependencies among transactions",
+      "title": "Could not serialize access: read/write dependencies",
       "category": "app-errors",
       "collectorKey": "COULD_NOT_SERIALIZE_SERIALIZABLE",
       "tooltip": "Transaction could not be completed under SERIALIZABLE isolation level",
@@ -1971,7 +1971,7 @@
       "hasAnalysis": null
     },
     "U140": {
-      "title": "Range lower bound must be less than or equal to range upper bound",
+      "title": "Inconsistent range bounds",
       "category": "app-errors",
       "collectorKey": "INCONSISTENT_RANGE_BOUNDS",
       "tooltip": "Data contains range bounds in the incorrect order",
@@ -1982,7 +1982,7 @@
       "hasAnalysis": null
     },
     "V100": {
-      "title": "Duplicate key value violates unique constraint",
+      "title": "Unique constraint violation",
       "category": "constraint-violations",
       "collectorKey": "UNIQUE_CONSTRAINT_VIOLATION",
       "tooltip": "Unique constraint violated by INSERT/UPDATE",
@@ -1993,7 +1993,7 @@
       "hasAnalysis": null
     },
     "V101": {
-      "title": "Insert or update / update or delete on table violates foreign key constraint",
+      "title": "Foreign key constraint violation",
       "category": "constraint-violations",
       "collectorKey": "FOREIGN_KEY_CONSTRAINT_VIOLATION",
       "tooltip": "Foreign key constraint violated by INSERT/UPDATE/DELETE",
@@ -2004,7 +2004,7 @@
       "hasAnalysis": null
     },
     "V102": {
-      "title": "Null value in column violates not-null constraint",
+      "title": "Not-NULL constraint violation",
       "category": "constraint-violations",
       "collectorKey": "NOT_NULL_CONSTRAINT_VIOLATION",
       "tooltip": "Not-null constraint on column is violated by INSERT/UPDATE",
@@ -2015,7 +2015,7 @@
       "hasAnalysis": null
     },
     "V103": {
-      "title": "New row for relation violates check constraint",
+      "title": "Check constraint violation",
       "category": "constraint-violations",
       "collectorKey": "CHECK_CONSTRAINT_VIOLATION",
       "tooltip": "Check constraint is violated by inserted/updated data",
@@ -2026,7 +2026,7 @@
       "hasAnalysis": null
     },
     "V104": {
-      "title": "Conflicting key value violates exclusion constraint",
+      "title": "Exclusion constraint violation",
       "category": "constraint-violations",
       "collectorKey": "EXCLUSION_CONSTRAINT_VIOLATION",
       "tooltip": "Exclusion constraint violated by inserted/updated data",
@@ -2059,7 +2059,7 @@
       "hasAnalysis": null
     },
     "W42": {
-      "title": "Checkpoints are occurring too frequently",
+      "title": "Checkpoints too frequent",
       "category": "wal-checkpoints",
       "collectorKey": "CHECKPOINT_TOO_FREQUENT",
       "tooltip": "Checkpoints are occurring very quickly, causing I/O impact",
@@ -2092,7 +2092,7 @@
       "hasAnalysis": null
     },
     "W45": {
-      "title": "Recovery restart point at ...",
+      "title": "Recovery restart point",
       "category": "wal-checkpoints",
       "collectorKey": "RESTARTPOINT_AT",
       "tooltip": "Reference for when a new safe restartpoint was established",
@@ -2103,7 +2103,7 @@
       "hasAnalysis": null
     },
     "W46": {
-      "title": "According to history file, WAL location belongs to timeline N",
+      "title": "Invalid WAL timeline",
       "category": "wal-checkpoints",
       "collectorKey": "STANDBY_INVALID_TIMELINE",
       "tooltip": "Phantom WAL segment file is associated to wrong timeline",
@@ -2147,7 +2147,7 @@
       "hasAnalysis": null
     },
     "W53": {
-      "title": "Backup complete, all required WAL segments have been archived",
+      "title": "Backup complete",
       "category": "wal-checkpoints",
       "collectorKey": "WAL_BASE_BACKUP_COMPLETE",
       "tooltip": "The pg_stop_backup command has succeeded (part of base backup)",

--- a/log-insights/app-errors/U115.mdx
+++ b/log-insights/app-errors/U115.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U115
-log_title: Subquery in FROM must have an alias
+log_title: Subquery in FROM must have alias
 log_category: app-errors
 collector_key: SUBQUERY_MISSING_ALIAS
 tooltip: The query is missing an alias name for a subquery

--- a/log-insights/app-errors/U116.mdx
+++ b/log-insights/app-errors/U116.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U116
-log_title: INSERT has more expressions than target columns
+log_title: INSERT does not match target columns
 log_category: app-errors
 collector_key: INSERT_TARGET_COLUMN_MISMATCH
 tooltip: "The # of columns in your INSERT statements are different than the # of values per row"

--- a/log-insights/app-errors/U125.mdx
+++ b/log-insights/app-errors/U125.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U125
-log_title: No unique or exclusion constraint matching the ON CONFLICT specification
+log_title: Unmatched ON CONFLICT specification
 log_category: app-errors
 collector_key: ON_CONFLICT_NO_CONSTRAINT_MATCH
 tooltip: Missing unique/exclusion constraint for conflict resolution in ON CONFLICT statement

--- a/log-insights/app-errors/U126.mdx
+++ b/log-insights/app-errors/U126.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U126
-log_title: ON CONFLICT DO UPDATE command cannot affect row a second time
+log_title: ON CONFLICT DO UPDATE affected row twice
 log_category: app-errors
 collector_key: ON_CONFLICT_ROW_AFFECTED_TWICE
 tooltip: INSERT statement contains the same row twice, as determined by ON CONFLICT constraint

--- a/log-insights/app-errors/U129.mdx
+++ b/log-insights/app-errors/U129.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U129
-log_title: Cannot drop table / Cannot drop object
+log_title: Cannot drop object
 log_category: app-errors
 collector_key: CANNOT_DROP
 tooltip: The statement failed to drop the referenced object

--- a/log-insights/app-errors/U132.mdx
+++ b/log-insights/app-errors/U132.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U132
-log_title: There is no parameter $1 / $n
+log_title: There is no parameter $n
 log_category: app-errors
 collector_key: PARAM_MISSING
 tooltip: The referenced parameter $n is missing

--- a/log-insights/app-errors/U138.mdx
+++ b/log-insights/app-errors/U138.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U138
-log_title: Could not serialize access due to concurrent update
+log_title: "Could not serialize access: concurrent update"
 log_category: app-errors
 collector_key: COULD_NOT_SERIALIZE_REPEATABLE_READ
 tooltip: UPDATE or DELETE was run concurrently on the same row with isolation level REPEATABLE READ

--- a/log-insights/app-errors/U139.mdx
+++ b/log-insights/app-errors/U139.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U139
-log_title: Could not serialize access due to read/write dependencies among transactions
+log_title: "Could not serialize access: read/write dependencies"
 log_category: app-errors
 collector_key: COULD_NOT_SERIALIZE_SERIALIZABLE
 tooltip: Transaction could not be completed under SERIALIZABLE isolation level

--- a/log-insights/app-errors/U140.mdx
+++ b/log-insights/app-errors/U140.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: U140
-log_title: Range lower bound must be less than or equal to range upper bound
+log_title: Inconsistent range bounds
 log_category: app-errors
 collector_key: INCONSISTENT_RANGE_BOUNDS
 tooltip: Data contains range bounds in the incorrect order

--- a/log-insights/autovacuum/A61.mdx
+++ b/log-insights/autovacuum/A61.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: A61
-log_title: Database must be vacuumed within N transactions (TXID Wraparound Warning)
+log_title: TXID wraparound warning
 log_category: autovacuum
 collector_key: TXID_WRAPAROUND_WARNING
 tooltip: Database is at risk of forced shutdown due to overdue VACUUM

--- a/log-insights/autovacuum/A62.mdx
+++ b/log-insights/autovacuum/A62.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: A62
-log_title: Database is not accepting commands to avoid wraparound data loss
+log_title: TXID wraparound critical
 log_category: autovacuum
 collector_key: TXID_WRAPAROUND_ERROR
 tooltip: The database has been interrupted due to imminent TXID wraparound - manual intervention required

--- a/log-insights/autovacuum/A64.mdx
+++ b/log-insights/autovacuum/A64.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: A64
-log_title: Autovacuum launcher shutting down
+log_title: Autovacuum launcher stopped
 log_category: autovacuum
 collector_key: AUTOVACUUM_LAUNCHER_SHUTTING_DOWN
 tooltip: The autovacuum launcher has been stopped

--- a/log-insights/autovacuum/A65.mdx
+++ b/log-insights/autovacuum/A65.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: A65
-log_title: Automatic vacuum of table completed
+log_title: Autovacuum completed
 log_category: autovacuum
 collector_key: AUTOVACUUM_COMPLETED
 tooltip: Automatic VACUUM for the referenced table has completed

--- a/log-insights/autovacuum/A66.mdx
+++ b/log-insights/autovacuum/A66.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: A66
-log_title: Automatic analyze of table completed
+log_title: Autoanalyze completed
 log_category: autovacuum
 collector_key: AUTOANALYZE_COMPLETED
 tooltip: Automatic ANALYZE for the referenced table has completed

--- a/log-insights/autovacuum/A67.mdx
+++ b/log-insights/autovacuum/A67.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: A67
-log_title: Skipping vacuum - lock not available
+log_title: Skipping vacuum due to lock
 log_category: autovacuum
 collector_key: SKIPPING_VACUUM_LOCK_NOT_AVAILABLE
 tooltip: Vacuum could not be started due to lock failure

--- a/log-insights/autovacuum/A68.mdx
+++ b/log-insights/autovacuum/A68.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: A68
-log_title: Skipping analyze - lock not available
+log_title: Skipping analyze due to lock
 log_category: autovacuum
 collector_key: SKIPPING_ANALYZE_LOCK_NOT_AVAILABLE
 tooltip: Vacuum could not be started due to lock failure

--- a/log-insights/connections/C22.mdx
+++ b/log-insights/connections/C22.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: C22
-log_title: Authentication failed / pg_hba.conf rejects connection
+log_title: Authentication failed
 log_category: connections
 collector_key: CONNECTION_REJECTED
 tooltip: New connection was rejected due to authentication/authorization errors

--- a/log-insights/connections/C24.mdx
+++ b/log-insights/connections/C24.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: C24
-log_title: Incomplete startup packet (client failed to connect)
+log_title: Client failed to connect
 log_category: connections
 collector_key: CONNECTION_CLIENT_FAILED_TO_CONNECT
 tooltip: The client opened a connection but didn't complete the initial process

--- a/log-insights/connections/C25.mdx
+++ b/log-insights/connections/C25.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: C25
-log_title: Could not receive data from client / connection to client lost
+log_title: Connection to client lost
 log_category: connections
 collector_key: CONNECTION_LOST
 tooltip: Network connection to the client was interrupted

--- a/log-insights/connections/C26.mdx
+++ b/log-insights/connections/C26.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: C26
-log_title: EOF on client connection with an open transaction
+log_title: Connection with open transaction lost
 log_category: connections
 collector_key: CONNECTION_LOST_OPEN_TX
 tooltip: Network interruption to client with an open transaction

--- a/log-insights/connections/C27.mdx
+++ b/log-insights/connections/C27.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: C27
-log_title: Terminating connection due to administrator command
+log_title: Terminating connection
 log_category: connections
 collector_key: CONNECTION_TERMINATED
 tooltip: This connection was terminated by a DBA / operator

--- a/log-insights/connections/C28.mdx
+++ b/log-insights/connections/C28.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: C28
-log_title: Remaining connection slots are reserved for superuser (out of connections)
+log_title: Too many connections
 log_category: connections
 collector_key: OUT_OF_CONNECTIONS
 tooltip: The number of connections has exceeded the max_connections setting

--- a/log-insights/constraint-violations/V100.mdx
+++ b/log-insights/constraint-violations/V100.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: V100
-log_title: Duplicate key value violates unique constraint
+log_title: Unique constraint violation
 log_category: constraint-violations
 collector_key: UNIQUE_CONSTRAINT_VIOLATION
 tooltip: Unique constraint violated by INSERT/UPDATE

--- a/log-insights/constraint-violations/V101.mdx
+++ b/log-insights/constraint-violations/V101.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: V101
-log_title: Insert or update / update or delete on table violates foreign key constraint
+log_title: Foreign key constraint violation
 log_category: constraint-violations
 collector_key: FOREIGN_KEY_CONSTRAINT_VIOLATION
 tooltip: Foreign key constraint violated by INSERT/UPDATE/DELETE

--- a/log-insights/constraint-violations/V102.mdx
+++ b/log-insights/constraint-violations/V102.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: V102
-log_title: Null value in column violates not-null constraint
+log_title: Not-NULL constraint violation
 log_category: constraint-violations
 collector_key: NOT_NULL_CONSTRAINT_VIOLATION
 tooltip: Not-null constraint on column is violated by INSERT/UPDATE

--- a/log-insights/constraint-violations/V103.mdx
+++ b/log-insights/constraint-violations/V103.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: V103
-log_title: New row for relation violates check constraint
+log_title: Check constraint violation
 log_category: constraint-violations
 collector_key: CHECK_CONSTRAINT_VIOLATION
 tooltip: Check constraint is violated by inserted/updated data

--- a/log-insights/constraint-violations/V104.mdx
+++ b/log-insights/constraint-violations/V104.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: V104
-log_title: Conflicting key value violates exclusion constraint
+log_title: Exclusion constraint violation
 log_category: constraint-violations
 collector_key: EXCLUSION_CONSTRAINT_VIOLATION
 tooltip: Exclusion constraint violated by inserted/updated data

--- a/log-insights/locks/L70.mdx
+++ b/log-insights/locks/L70.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: L70
-log_title: Process acquired lock on tuple / relation / object
+log_title: Process acquired lock
 log_category: locks
 collector_key: LOCK_ACQUIRED
 tooltip: Lock was successfully acquired after exceeding deadlock_timeout

--- a/log-insights/locks/L71.mdx
+++ b/log-insights/locks/L71.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: L71
-log_title: Process still waiting for lock on tuple / relation / object
+log_title: Process still waiting for lock
 log_category: locks
 collector_key: LOCK_WAITING
 tooltip: Lock has not been acquired yet after waiting for deadlock_timeout

--- a/log-insights/locks/L73.mdx
+++ b/log-insights/locks/L73.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: L73
-log_title: Deadlock detected (transaction rolled back)
+log_title: Deadlock detected
 log_category: locks
 collector_key: LOCK_DEADLOCK_DETECTED
 tooltip: Deadlock between two connections was found and resolved by transaction cancellation

--- a/log-insights/locks/L74.mdx
+++ b/log-insights/locks/L74.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: L74
-log_title: Process avoided deadlock by rearranging queue order
+log_title: Process avoided deadlock
 log_category: locks
 collector_key: LOCK_DEADLOCK_AVOIDED
 tooltip: Deadlock between two connections was found and resolved by lock wait queue reordering

--- a/log-insights/server/S1.mdx
+++ b/log-insights/server/S1.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: S1
-log_title: Server process was terminated / Terminating connection because of crash
+log_title: Server process was terminated
 log_category: server
 collector_key: SERVER_CRASHED
 tooltip: Postgres server processes have crashed, server will be restarted

--- a/log-insights/server/S10.mdx
+++ b/log-insights/server/S10.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: S10
-log_title: Worker process exited / terminated by signal
+log_title: Worker process exited
 log_category: server
 collector_key: SERVER_PROCESS_EXITED
 tooltip: Internal process has exited - check exit code/signal

--- a/log-insights/server/S3.mdx
+++ b/log-insights/server/S3.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: S3
-log_title: Database system was interrupted (server starting)
+log_title: Database system was interrupted
 log_category: server
 collector_key: SERVER_START_RECOVERING
 tooltip: Postgres has restarted after a crash/forceful shutdown

--- a/log-insights/server/S6.mdx
+++ b/log-insights/server/S6.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: S6
-log_title: "Invalid page / page verification failed (data corrupted)"
+log_title: Data corrupted
 log_category: server
 collector_key: SERVER_INVALID_CHECKSUM
 tooltip: Failed to access table or index data due to corruption

--- a/log-insights/server/S7.mdx
+++ b/log-insights/server/S7.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: S7
-log_title: "Temporary file: path ..., size ... (temp file created)"
+log_title: Temp file created
 log_category: server
 collector_key: SERVER_TEMP_FILE_CREATED
 tooltip: Sorting/hashing operation was done through a file instead of in memory

--- a/log-insights/standby/B90.mdx
+++ b/log-insights/standby/B90.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: B90
-log_title: Restored log file from archive (WAL replay)
+log_title: Replayed WAL file from archive
 log_category: standby
 collector_key: STANDBY_RESTORED_WAL_FROM_ARCHIVE
 tooltip: Postgres has replayed a WAL file from the archive using restore_command

--- a/log-insights/standby/B91.mdx
+++ b/log-insights/standby/B91.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: B91
-log_title: Started streaming WAL from primary
+log_title: Streaming WAL from primary
 log_category: standby
 collector_key: STANDBY_STARTED_STREAMING
 tooltip: Streaming replication has successfully started/resumed

--- a/log-insights/standby/B92.mdx
+++ b/log-insights/standby/B92.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: B92
-log_title: Could not receive data from WAL stream
+log_title: Could not receive WAL data
 log_category: standby
 collector_key: STANDBY_STREAMING_INTERRUPTED
 tooltip: Streaming replication was interrupted due to a network issue

--- a/log-insights/standby/B93.mdx
+++ b/log-insights/standby/B93.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: B93
-log_title: Terminating walreceiver process due to administrator command
+log_title: Terminating walreceiver
 log_category: standby
 collector_key: STANDBY_STOPPED_STREAMING
 tooltip: Streaming replication has stopped due to intervention

--- a/log-insights/standby/B95.mdx
+++ b/log-insights/standby/B95.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: B95
-log_title: Canceling statement due to conflict with recovery
+log_title: Canceling statement due to recovery conflict
 log_category: standby
 collector_key: STANDBY_STATEMENT_CANCELED
 tooltip: Statement tried to access data that is about to be removed

--- a/log-insights/statements/T81.mdx
+++ b/log-insights/statements/T81.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: T81
-log_title: Canceling statement due to statement timeout
+log_title: Canceling statement due to timeout
 log_category: statements
 collector_key: STATEMENT_CANCELED_TIMEOUT
 tooltip: Statement was canceled since it ran longer than statement_timeout

--- a/log-insights/statements/T82.mdx
+++ b/log-insights/statements/T82.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: T82
-log_title: Canceling statement due to user request
+log_title: Canceling statement due to request
 log_category: statements
 collector_key: STATEMENT_CANCELED_USER
 tooltip: Statement was canceled due to operator calling pg_cancel_backend

--- a/log-insights/wal-checkpoints/W42.mdx
+++ b/log-insights/wal-checkpoints/W42.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: W42
-log_title: Checkpoints are occurring too frequently
+log_title: Checkpoints too frequent
 log_category: wal-checkpoints
 collector_key: CHECKPOINT_TOO_FREQUENT
 tooltip: Checkpoints are occurring very quickly, causing I/O impact

--- a/log-insights/wal-checkpoints/W45.mdx
+++ b/log-insights/wal-checkpoints/W45.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: W45
-log_title: Recovery restart point at ...
+log_title: Recovery restart point
 log_category: wal-checkpoints
 collector_key: RESTARTPOINT_AT
 tooltip: Reference for when a new safe restartpoint was established

--- a/log-insights/wal-checkpoints/W46.mdx
+++ b/log-insights/wal-checkpoints/W46.mdx
@@ -1,6 +1,6 @@
 ---
 log_classification: W46
-log_title: According to history file, WAL location belongs to timeline N
+log_title: Invalid WAL timeline
 log_category: wal-checkpoints
 collector_key: STANDBY_INVALID_TIMELINE
 tooltip: Phantom WAL segment file is associated to wrong timeline

--- a/log-insights/wal-checkpoints/W53.mdx
+++ b/log-insights/wal-checkpoints/W53.mdx
@@ -1,7 +1,7 @@
 ---
 work_in_progress: true
 log_classification: W53
-log_title: Backup complete, all required WAL segments have been archived
+log_title: Backup complete
 log_category: wal-checkpoints
 collector_key: WAL_BASE_BACKUP_COMPLETE
 tooltip: The pg_stop_backup command has succeeded (part of base backup)


### PR DESCRIPTION
Use terser titles for Log Insights log classifications. This will let
us update the UI to make log classifications easier to recognize.
