### PR TITLE
Add normalized query to getQueryStats documentation

### DIFF
--- a/api/queries/getQueryStats.mdx
+++ b/api/queries/getQueryStats.mdx
@@ -24,6 +24,7 @@ Fields returned:
 
 * **`id` (number)**<br/>Unique identifier for this query in the pganalyze system
 * **`queryUrl` (string)**<br/>URL to the pganalyze query page
+* **`normalizedQuery` (string)**<br/>Full query text, normalized to remove inline parameters
 * **`truncatedQuery` (string)**<br/>Shortened query text up to 100 characters (same as displayed in "Query Performance" overview)
 * **`queryComment` (string)**<br/>First comment contained in the query (this is taken from the full query string, not just the truncated one)
 * **`statementType` (array of strings)**<br/>List of statement type(s) used in this query
@@ -44,6 +45,7 @@ query {
   getQueryStats(databaseId: 12345) {
     id
     queryUrl
+    normalizedQuery
     truncatedQuery
     statementType
     totalCalls
@@ -58,7 +60,7 @@ Using `curl`:
 
 ```bash
 curl -XPOST -H 'Authorization: Token XXXXXXX' \
-  -F 'query=query { getQueryStats(databaseId: 12345) { id, queryUrl, truncatedQuery, statementType, totalCalls, avgTime, bufferHitRatio, pctOfTotal } }' \
+  -F 'query=query { getQueryStats(databaseId: 12345) { id, queryUrl, normalizedQuery, truncatedQuery, statementType, totalCalls, avgTime, bufferHitRatio, pctOfTotal } }' \
   https://app.pganalyze.com/graphql
 ```
 
@@ -69,6 +71,7 @@ curl -XPOST -H 'Authorization: Token XXXXXXX' \
       {
         "id":"678910",
         "queryUrl": "https://app.pganalyze.com/databases/12345/queries/678910",
+        "normalizedQuery": "UPDATE \"pgbench_accounts\" SET abalance = $1 WHERE \"aid\" = $2",
         "truncatedQuery": "UPDATE \"pgbench_accounts\" SET abalance = $1 WHERE \"aid\" = $2",
         "statementType": [
           "UPDATE"


### PR DESCRIPTION
`getQueryStats` supports returning the full normalized query, but that wasn't in the public documentation. This change was prompted by a support request asking for a way to export the full query text.