### PR TITLE
Remove secondary URL from getIssues documentation

### DIFF
--- a/api/queries/getIssues.mdx
+++ b/api/queries/getIssues.mdx
@@ -30,7 +30,6 @@ Fields returned:
       * **`kind` (String)**<br/>Type of object this issue references
       * **`name` (String)**<br/>Name of the object this issue references
       * **`url` (String)**<br/>URL to the object this issue references
-      * **`secondaryUrl` (String)** (optional)<br/>Secondary URL for an alternate object this issue references (e.g. active queries reference both the connection as well as the query object)
       * **`queryText` (String)** (optional)<br/>For query references, statement text of the query
 
 ## Example


### PR DESCRIPTION
This field has long been deprecated, and was recently removed from the API.