### PR TITLE
Add copy capability to CodeBlocks in docs

### DIFF
--- a/components/CodeBlock.gatsby.tsx
+++ b/components/CodeBlock.gatsby.tsx
@@ -8,15 +8,12 @@ import styles from "./style.module.scss";
 // Utility to extract text from children
 function getTextFromChildren(children: React.ReactNode): string {
   if (typeof children === "string") {
-    console.log("getTextFromChildren was a string", children); 
     return children;
   }
   if (Array.isArray(children)) {
-    console.log("getTextFromChildren was an array", children);
     return children.map(getTextFromChildren).join(" \n");
   }
   if (typeof children === "object" && children && "props" in children) {
-    console.log("getTextFromChildren was an object", children);
     return getTextFromChildren((children as any).props.children);
   } 
   return "";
@@ -43,7 +40,7 @@ const CodeBlock = ({children, language = 'text', style, hideCopy = false}: Props
     <div className={styles.copyBlock}>
       <div className='gatsby-highlight' data-language={language}>
         <pre className={`language-${language}`} style={style}>
-          <code className={`language-${language}`} ref={ref}>{getTextFromChildren(children)}</code>
+          <code className={`language-${language}`} ref={ref}>{children}</code>
         </pre>
       </div>
      {!hideCopy && (

--- a/components/CodeBlock.gatsby.tsx
+++ b/components/CodeBlock.gatsby.tsx
@@ -1,15 +1,35 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
+import CopyToClipboard from "./CopyToClipboard";
 import hljs from "highlight.js/lib/core";
 import json from "highlight.js/lib/languages/json";
 import sql from "highlight.js/lib/languages/pgsql";
+import styles from "./style.module.scss";
 
-type Props = {
-   language: string;
-   style?: React.CSSProperties;
-   children: React.ReactNode;
+// Utility to extract text from children
+function getTextFromChildren(children: React.ReactNode): string {
+  if (typeof children === "string") {
+    console.log("getTextFromChildren was a string", children); 
+    return children;
+  }
+  if (Array.isArray(children)) {
+    console.log("getTextFromChildren was an array", children);
+    return children.map(getTextFromChildren).join(" \n");
+  }
+  if (typeof children === "object" && children && "props" in children) {
+    console.log("getTextFromChildren was an object", children);
+    return getTextFromChildren((children as any).props.children);
+  } 
+  return "";
 }
 
-const CodeBlock = ({children, language = 'text', style}: Props) => {
+type Props = {
+   language?: string;
+   style?: React.CSSProperties;
+   children: React.ReactNode;
+   hideCopy?: boolean;
+}
+
+const CodeBlock = ({children, language = 'text', style, hideCopy = false}: Props) => {
   const ref = useRef<HTMLElement>();
   useEffect(() => {
     // This matches the prefix used by gatsby-remark-prismjs
@@ -20,12 +40,27 @@ const CodeBlock = ({children, language = 'text', style}: Props) => {
     hljs.highlightElement(ref.current);
   }, [ref]);
   return (
-    <div className='gatsby-highlight' data-language={language}>
-      <pre className={`language-${language}`} style={style}>
-        <code className={`language-${language}`} ref={ref}>{children}</code>
-      </pre>
+    <div className={styles.copyBlock}>
+      <div className='gatsby-highlight' data-language={language}>
+        <pre className={`language-${language}`} style={style}>
+          <code className={`language-${language}`} ref={ref}>{getTextFromChildren(children)}</code>
+        </pre>
+      </div>
+     {!hideCopy && (
+        <CopyToClipboard
+          content={getTextFromChildren(children)}  // Ensure content is passed to the CopyToClipboard component
+          label=""
+          className={styles.copyIcon}
+        />
+      )}
     </div>
   )
+}
+
+const CodeBlockContext = React.createContext<React.ComponentType<Props>>(CodeBlock);
+
+export const useCodeBlock = () => {
+  return useContext(CodeBlockContext);
 }
 
 export default CodeBlock;

--- a/components/CodeBlock.gatsby.tsx
+++ b/components/CodeBlock.gatsby.tsx
@@ -40,7 +40,7 @@ const CodeBlock = ({children, language = 'text', style, hideCopy = false}: Props
     <div className={styles.copyBlock}>
       <div className='gatsby-highlight' data-language={language}>
         <pre className={`language-${language}`} style={style}>
-          <code className={`language-${language}`} ref={ref}>{children}</code>
+          <code className={`language-${language}`} ref={ref}>{getTextFromChildren(children)}</code>
         </pre>
       </div>
      {!hideCopy && (

--- a/components/CopyToClipboard/index.tsx
+++ b/components/CopyToClipboard/index.tsx
@@ -28,7 +28,7 @@ const CopyToClipboard: React.FunctionComponent<Props> = ({
   label,
   title,
 }) => {
-  const unmounted = useUnmounted();
+  const unmounted = useRef(false);
   const [copied, setCopied] = useState(false);
   const [waitingForContent, setWaitingForContent] = useState(false);
   const [copyError, setCopyError] = useState(null);
@@ -37,7 +37,7 @@ const CopyToClipboard: React.FunctionComponent<Props> = ({
     return null;
   }
 
-  const handleCopy = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (clipboard) {
       let actualContent;
@@ -53,6 +53,7 @@ const CopyToClipboard: React.FunctionComponent<Props> = ({
       } else {
         actualContent = content;
       }
+
       clipboard
         .writeText(actualContent)
         .then(() => {
@@ -93,10 +94,18 @@ const CopyToClipboard: React.FunctionComponent<Props> = ({
   }
 
   return (
-    <a href="" className={className} onClick={handleCopy}>
-      {copyIcon} {label}
-    </a>
+    <button
+      className={className}
+      title={title}
+      onClick={handleCopy}
+      disabled={waitingForContent}
+      type="button"
+    >
+      {copyIcon}
+      {label}
+    </button>
   );
+
 };
 
 export default CopyToClipboard;

--- a/components/CopyToClipboard/index.tsx
+++ b/components/CopyToClipboard/index.tsx
@@ -28,7 +28,7 @@ const CopyToClipboard: React.FunctionComponent<Props> = ({
   label,
   title,
 }) => {
-  const unmounted = useRef(false);
+  const unmounted = useUnmounted();
   const [copied, setCopied] = useState(false);
   const [waitingForContent, setWaitingForContent] = useState(false);
   const [copyError, setCopyError] = useState(null);

--- a/components/MonitoringUserSetupInstructions.tsx
+++ b/components/MonitoringUserSetupInstructions.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useCodeBlock } from "./CodeBlock";
+import { useCodeBlock } from "./CodeBlock.gatsby";
 import { useGeneratedPassword } from "./WithGeneratedPassword";
 
 type Props = {
@@ -33,9 +33,10 @@ export const MonitoringUserPerDatabaseHelpers: React.FunctionComponent<{ usernam
         Then, connect to each database that you plan to monitor on this server as {adminUserStr} and
         run the following to enable the collection of additional column statistics and extended statistics:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
+
 
 DROP FUNCTION IF EXISTS pganalyze.get_column_stats;
 CREATE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
@@ -85,7 +86,7 @@ export const MonitoringUserColumnStats: React.FunctionComponent<{ username: stri
         Then, connect to each database that you plan to monitor on this server as {adminUserStr} and
         run the following to enable the collection of additional column statistics:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
 DROP FUNCTION IF EXISTS pganalyze.get_column_stats;
@@ -120,7 +121,7 @@ export const MonitoringUserExtStats: React.FunctionComponent<{ username: string,
         Then, connect to each database that you plan to monitor on this server as {adminUserStr} and
         run the following to enable the collection of additional extended statistics:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
 DROP FUNCTION IF EXISTS pganalyze.get_relation_stats_ext;
@@ -151,7 +152,7 @@ export const MonitoringUserExplain: React.FunctionComponent<{ username: string }
   const CodeBlock = useCodeBlock();
   return (
     <>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
 CREATE OR REPLACE FUNCTION pganalyze.explain(query text, params text[]) RETURNS text AS
@@ -202,7 +203,7 @@ export const MonitoringUserLogRead: React.FunctionComponent<{ username: string }
   const CodeBlock = useCodeBlock();
   return (
     <>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE SCHEMA IF NOT EXISTS pganalyze;
 GRANT USAGE ON SCHEMA pganalyze TO ${username};
 CREATE OR REPLACE FUNCTION pganalyze.read_log_file(log_filename text, read_offset bigint, read_length bigint) RETURNS text AS
@@ -235,7 +236,7 @@ const MonitoringUserBase: React.FunctionComponent<{
   const CodeBlock = useCodeBlock();
   return (
     <>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE USER pganalyze WITH PASSWORD '${password}' CONNECTION LIMIT 5;
 ${noPgMonitor ? '' : 'GRANT pg_monitor TO pganalyze;\n'}
 CREATE SCHEMA pganalyze;
@@ -250,7 +251,7 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;` : ''}`}
       <p>
         If you enable the optional reset mode (usually not required), you will also need this helper method:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
       {`CREATE OR REPLACE FUNCTION pganalyze.reset_stat_statements() RETURNS SETOF void AS
 $$
   /* pganalyze-collector */ SELECT * FROM public.pg_stat_statements_reset();
@@ -266,7 +267,7 @@ export const MonitoringUserBaseForGCP: React.FunctionComponent<{
   const CodeBlock = useCodeBlock();
   return (
     <>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`ALTER ROLE "${username}" CONNECTION LIMIT 5;
 GRANT pg_monitor TO "${username}";
 CREATE SCHEMA pganalyze;
@@ -276,7 +277,7 @@ GRANT USAGE ON SCHEMA public TO "${username}";`}
       <p>
         If you enable the optional reset mode (usually not required), you will also need this helper method:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
       {`CREATE OR REPLACE FUNCTION pganalyze.reset_stat_statements() RETURNS SETOF void AS
 $$
   /* pganalyze-collector */ SELECT * FROM public.pg_stat_statements_reset();
@@ -305,7 +306,7 @@ export const NoPgMonitorPgStatStatementsHelpers: React.FunctionComponent<{
         database and create a function like the following (replace <code>&lt;username&gt;</code> with
         the actual user name):
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE OR REPLACE FUNCTION pganalyze.get_stat_statements_<username>(showtext boolean = true)
 RETURNS SETOF pg_stat_statements AS
 $$
@@ -316,7 +317,7 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
         For example, if you have two users, <code>app</code> and <code>analytics</code>, you'll
         need to log in as <code>app</code> and run:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE OR REPLACE FUNCTION pganalyze.get_stat_statements_app(showtext boolean = true)
 RETURNS SETOF pg_stat_statements AS
 $$
@@ -326,7 +327,7 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
       <p>
         Then, log in as <code>analytics</code> and run:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE OR REPLACE FUNCTION pganalyze.get_stat_statements_analytics(showtext boolean = true)
 RETURNS SETOF pg_stat_statements AS
 $$
@@ -336,7 +337,7 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
       <p>
         Make sure to also log in as {adminUserStr} and create a function for that user:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE OR REPLACE FUNCTION pganalyze.get_stat_statements_${adminUsername}(showtext boolean = true)
 RETURNS SETOF pg_stat_statements AS
 $$
@@ -347,7 +348,7 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
         Then, still logged in as {adminUserStr}, create a helper function to combine these. For example,
         for the case of the three users above, the final helper function will look like this:
       </p>
-      <CodeBlock>
+      <CodeBlock language="sql">
         {`CREATE OR REPLACE FUNCTION pganalyze.get_stat_statements(showtext boolean = true)
 RETURNS SETOF pg_stat_statements AS
 $$

--- a/components/style.module.scss
+++ b/components/style.module.scss
@@ -73,7 +73,7 @@
     position: absolute;
     display: block;
     right: 8px;
-    top: 4px;
+    top: 8px;
     font-size: 16px;
     color: #c8c8c8;
     background-color: grey;

--- a/components/style.module.scss
+++ b/components/style.module.scss
@@ -65,3 +65,25 @@
   color: #5cb85c;
   vertical-align: baseline;
 }
+
+.copyBlock {
+  position: relative;
+
+  .copyIcon {
+    position: absolute;
+    display: block;
+    right: 8px;
+    top: 4px;
+    font-size: 16px;
+    color: #c8c8c8;
+    background-color: grey;
+    padding: 2px 6px;
+    border: 1px solid #f2f2f2;
+    border-radius: 5px;
+
+    &:hover {
+      color: #f6f6f6;
+    }
+  }
+}
+

--- a/install/amazon_rds/01_configure_rds_instance.mdx
+++ b/install/amazon_rds/01_configure_rds_instance.mdx
@@ -17,10 +17,10 @@ Connect to your database as an RDS superuser (usually the credentials you create
 
 Run the following SQL commands to enable the extension, and make sure it was installed correctly:
 
-```
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
-SELECT * FROM pg_stat_statements LIMIT 1;
-```
+<CodeBlock language="sql">
+{`CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+SELECT * FROM pg_stat_statements LIMIT 1;`}
+</CodeBlock>
 
 This should return one row of query statistics information.
 
@@ -53,5 +53,5 @@ this additional information in the dashboard as well.
 <PublicOnly>
   <br />
   <br />
-  <div><SignupCTA event-label="Docs"></SignupCTA></div>
+  <div><SignupCTA event-label="Docs" /></div>
 </PublicOnly>

--- a/install/amazon_rds/01_configure_rds_instance.mdx
+++ b/install/amazon_rds/01_configure_rds_instance.mdx
@@ -18,7 +18,7 @@ Connect to your database as an RDS superuser (usually the credentials you create
 Run the following SQL commands to enable the extension, and make sure it was installed correctly:
 
 <CodeBlock language="sql">
-{`CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+{`CREATE EXTENSION IF NOT EXISTS pg_stat_statements;\n
 SELECT * FROM pg_stat_statements LIMIT 1;`}
 </CodeBlock>
 


### PR DESCRIPTION
This is just an initial PR to add a copy button to code blocks throughout docs. The work appears to have been started at one point but not fully implemented. I originally had most of the current markdown code blocks converted until I realized that there is an issue with multi-line strings that I'm struggling to fix before applying more widely.

A few note:
- I chose to just update the existing `CodeBlock.gatsby.tsx` since it was already being referenced a few places rather than have multiple components.
- I also didn't use the existing `CopyCodeBlock` component because it was more simplistic without code formatting and currently not used anywhere
- I'll note the what the issue is in the two example modified files - one MDX file, one TSX file - separately, but in essense:
  - In the MDX file, whenever the content string has an empty line carriage return, it appears to be interpreted as an array of elements with the first one not terminated with a closing `}` as expected. (ie. `unexpected token...`)
  - In the MDX, if I directly add `\n` for carriage returns, it's happy to honor them
  - In the TSX, it honors the string no matter how many carriage returns there are. I think that makes sense because the TSX is parsing the string correctly, but somehow the MDX doesn't pass the string as a real, true string it seems, even when it's typed as such.

Assuming we can figure this out, then I'll plan to merge this PR and then update other files in batches since there's likely to be ~120 total to ensure docs continues to be accessible.