### PR TITLE
Correct a TypeScript definition for Issue

### DIFF
--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -349,7 +349,7 @@ export type IssueReferenceTable = {
 
 export type IssueType = {
   references?: {
-    referent: IssueReferenceBackend | IssueReferenceIndex | IssueReferenceTable | unknown;
+    referent?: IssueReferenceBackend | IssueReferenceIndex | IssueReferenceTable | unknown;
   }[],
   detailsJson: string;
 };


### PR DESCRIPTION
The upstream type marks the `referent` field as optional. This should
match.
