### PR TITLE
Query Tuning: Correct definition of explain_analyze helper

### DIFF
--- a/components/helperSQL.ts
+++ b/components/helperSQL.ts
@@ -29,14 +29,18 @@ BEGIN
   END LOOP;
   explain_prefix := explain_prefix || ') ';
 
-  SELECT COALESCE('(' || pg_catalog.array_to_string(
-    ARRAY(
-      SELECT pg_catalog.quote_literal(p)
-      FROM pg_catalog.unnest(params) _(p)
-    ),
-    ',',
-    'NULL'
-  ) || ')', '') INTO params_str;
+  IF cardinality(params) > 0 THEN
+    SELECT '(' || pg_catalog.array_to_string(
+      ARRAY(
+        SELECT pg_catalog.quote_literal(p)
+        FROM pg_catalog.unnest(params) _(p)
+      ),
+      ',',
+      'NULL'
+    ) || ')' INTO params_str;
+  ELSE
+    SELECT '' INTO params_str;
+  END IF;
   SELECT COALESCE('(' || pg_catalog.string_agg(
     CASE
       WHEN p ~ '^[a-z_][a-z0-9_]*(\\[\\])?$' THEN p


### PR DESCRIPTION
This was intended to match https://github.com/pganalyze/collector/pull/700, but missed subsequent changes to the function definition based on review feedback by accident. This caused errors in cases where no params were passed to the function.