### PR TITLE
Interpolate host to fix TypeScript check

### DIFF
--- a/components/VerifyConnection.tsx
+++ b/components/VerifyConnection.tsx
@@ -7,7 +7,7 @@ export const VerifyConnection: React.FunctionComponent<{host:string}> = ({host})
   const CodeBlock = useCodeBlock();
   const password = useGeneratedPassword();
   return (
-    <CodeBlock>{`PGPASSWORD=${password} psql -h {host} -d mydatabase -U pganalyze`}</CodeBlock>
+    <CodeBlock>{`PGPASSWORD=${password} psql -h ${host} -d mydatabase -U pganalyze`}</CodeBlock>
   )
 }
 


### PR DESCRIPTION
This change unblocks https://github.com/pganalyze/pganalyze/pull/5032.

When trying to update the pganalyze/pganalyze/docs submodule, the type checker found an error:
```
docs/components/VerifyConnection.tsx:6:74 - error TS6133: 'host' is declared but its value is never read.

6 export const VerifyConnection: React.FunctionComponent<{host:string}> = ({host}) => {
                                                                           ~~~~~~


Found 1 error in docs/components/VerifyConnection.tsx:6
```
The issue is in the template literal where `{host}` is treated as a literal string instead of being interpolated. This fix changes `{host}` to `${host}` to properly interpolate the prop value, which resolves the TypeScript error.