### PR TITLE
Add docs for how to enable pg_hint_plan

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -1084,6 +1084,10 @@
       "title": "Setting up the Collector Workflow",
       "path": "/docs/workbooks/collector-workflow"
     },
+    "workbooks/enabling_pg_hint_plan": {
+      "title": "Enabling pg_hint_plan",
+      "path": "/docs/workbooks/enabling_pg_hint_plan"
+    },
     "workbooks/how-to-use-workbooks": {
       "title": "How to Optimize Slow Queries with Workbooks",
       "path": "/docs/workbooks/how-to-use-workbooks"

--- a/workbooks/enabling_pg_hint_plan.mdx
+++ b/workbooks/enabling_pg_hint_plan.mdx
@@ -22,12 +22,8 @@ Below is an example of installing `pg_hint_plan` from a binary package:
 
 You don't need to run `CREATE EXTENSION` for `pg_hint_plan` unless you plan to
 use the hint table (in most cases, you won't need it).
-You can load it with the `LOAD` command (for the current session), or via
-`shared_preload_libraries` (to enable it globally).
-
-<CodeBlock language="bash">
-{`LOAD 'pg_hint_plan';`}
-</CodeBlock>
+You can load it for testing with the `LOAD 'pg_hint_plan'` command (for the
+current session), or via `shared_preload_libraries` (to enable it globally).
 
 ## Installing and enabling (Cloud providers)
 
@@ -57,8 +53,11 @@ group
 
 ### Azure Database for PostgreSQL
 
-* Enable `PG_HINT_PLAN` in the Server Parameters page
+* Allowlist the `pg_hint_plan` extension by adding `PG_HINT_PLAN` to the
+  `azure.extensions` parameter in the Server Parameters page
   * See [Enabling pg_stat_statements](/docs/install/azure_database/01_configure_azure_instance#enabling-pg_stat_statements)
     section for how to tweak the server parameters
-* Restart the instance to apply the change
+* Load `pg_hint_plan` by adding `PG_HINT_PLAN` to the `shared_preload_libraries`
+  parameter in the Server Parameters page
+* Save and Restart to save and apply changes the change
 * Run `CREATE EXTENSION pg_hint_plan;`

--- a/workbooks/enabling_pg_hint_plan.mdx
+++ b/workbooks/enabling_pg_hint_plan.mdx
@@ -1,0 +1,64 @@
+---
+title: 'Enabling pg_hint_plan'
+backlink_href: /docs/query-tuning
+backlink_title: 'Query Tuning'
+---
+
+`pg_hint_plan` is a PostgreSQL extension that offers the possibility to tweak
+PostgreSQL execution plans using so-called "hints" in SQL comments.
+
+This can help you guide the planner to pick or avoid specific execution plans,
+which is useful for tuning queries.
+
+## Installing and enabling (Self-managed)
+
+For self-managed servers, install `pg_hint_plan` either by building a binary
+module from the code, or from a binary package for Debian or Ubuntu.
+Below is an example of installing `pg_hint_plan` from a binary package:
+
+<CodeBlock language="bash">
+{`sudo apt install postgresql-<postgres version>-pg-hint-plan`}
+</CodeBlock>
+
+You don't need to run `CREATE EXTENSION` for `pg_hint_plan` unless you plan to
+use the hint table (in most cases, you won't need it).
+You can load it with the `LOAD` command (for the current session), or via
+`shared_preload_libraries` (to enable it globally).
+
+<CodeBlock language="bash">
+{`LOAD 'pg_hint_plan';`}
+</CodeBlock>
+
+## Installing and enabling (Cloud providers)
+
+For the cloud providers, the extension is usually available so you don't need to
+do a special thing to install.
+
+To enable `pg_hint_plan`, each provider has slightly different ways, however the
+basic flow is the same. Add it in `shared_preload_libraries`, restart, then run
+`CREATE EXTENSION pg_hint_plan;`.
+
+### Amazon RDS for PostgreSQL or Amazon Aurora PostgreSQL
+
+* Add `pg_hint_plan` to the `shared_preload_libraries` by tweaking the parameter
+group
+  * See the [the troubleshooting document about pg_stat_statements](/docs/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries)
+    for how to tweak the parameter group
+* Restart the instance to apply the change
+* Run `CREATE EXTENSION pg_hint_plan;`
+
+### Google Cloud SQL
+
+* Set the `cloudsql.enable_pg_hint_plan` flag to `on`
+  * See [Configure database flags](https://cloud.google.com/sql/docs/postgres/flags)
+    Google Cloud SQL documentation for how to set flags
+* Save the change and restart (automatically triggered as the change requires restart)
+* For Google Cloud SQL, no need to run `CREATE EXTENSION`
+
+### Azure Database for PostgreSQL
+
+* Enable `PG_HINT_PLAN` in the Server Parameters page
+  * See [Enabling pg_stat_statements](/docs/install/azure_database/01_configure_azure_instance#enabling-pg_stat_statements)
+    section for how to tweak the server parameters
+* Restart the instance to apply the change
+* Run `CREATE EXTENSION pg_hint_plan;`

--- a/workbooks/enabling_pg_hint_plan.mdx
+++ b/workbooks/enabling_pg_hint_plan.mdx
@@ -1,23 +1,33 @@
 ---
 title: 'Enabling pg_hint_plan'
-backlink_href: /docs/query-tuning
-backlink_title: 'Query Tuning'
+backlink_href: /docs/workbooks
+backlink_title: 'Workbooks'
 ---
 
-`pg_hint_plan` is a PostgreSQL extension that offers the possibility to tweak
+`pg_hint_plan` is a PostgreSQL module that offers the possibility to tweak
 PostgreSQL execution plans using so-called "hints" in SQL comments.
 
-This can help you guide the planner to pick or avoid specific execution plans,
-which is useful for tuning queries.
+It is generally preferable to guide the planner by tweaking [planner settings](https://www.postgresql.org/docs/current/runtime-config-query.html#RUNTIME-CONFIG-QUERY-CONSTANTS),
+ensuring statistics are representative of table contents (e.g., [SET STATISTICS](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-DESC-SET-STATISTICS)),
+and using [Extended Statistics](https://www.postgresql.org/docs/current/planner-stats.html#PLANNER-STATS-EXTENDED)
+if necessary.
+However, in some situations, the above options may not be available, and in
+these cases, `pg_plan` can help you guide the planner to pick or avoid specific
+execution plans, which is useful for tuning queries.
 
 ## Installing and enabling (Self-managed)
 
 For self-managed servers, install `pg_hint_plan` either by building a binary
-module from the code, or from a binary package for Debian or Ubuntu.
+module from the code, or from a binary package.
+
 Below is an example of installing `pg_hint_plan` from a binary package:
 
 <CodeBlock language="bash">
-{`sudo apt install postgresql-<postgres version>-pg-hint-plan`}
+{`# For Debian or Ubuntu
+sudo apt install postgresql-<postgres version>-pg-hint-plan
+
+# For RHEL-based systems (assuming the PostgreSQL Yum repository is already enabled)
+sudo dnf install pg_hint_plan_<postgres version>`}
 </CodeBlock>
 
 You don't need to run `CREATE EXTENSION` for `pg_hint_plan` unless you plan to
@@ -27,16 +37,16 @@ current session), or via `shared_preload_libraries` (to enable it globally).
 
 ## Installing and enabling (Cloud providers)
 
-For the cloud providers, the extension is usually available so you don't need to
-do a special thing to install.
+For cloud providers, the module is usually available so no separate install step
+is required.
 
-To enable `pg_hint_plan`, each provider has slightly different ways, however the
+Each provider has a slightly different way to enable `pg_hint_plan`, however the
 basic flow is the same. Add it in `shared_preload_libraries`, restart, then run
 `CREATE EXTENSION pg_hint_plan;`.
 
 ### Amazon RDS for PostgreSQL or Amazon Aurora PostgreSQL
 
-* Add `pg_hint_plan` to the `shared_preload_libraries` by tweaking the parameter
+* Add `pg_hint_plan` to `shared_preload_libraries` by tweaking the parameter
 group
   * See the [the troubleshooting document about pg_stat_statements](/docs/install/troubleshooting/rds_pg_stat_statements_shared_preload_libraries)
     for how to tweak the parameter group
@@ -57,7 +67,7 @@ group
   `azure.extensions` parameter in the Server Parameters page
   * See [Enabling pg_stat_statements](/docs/install/azure_database/01_configure_azure_instance#enabling-pg_stat_statements)
     section for how to tweak the server parameters
-* Load `pg_hint_plan` by adding `PG_HINT_PLAN` to the `shared_preload_libraries`
+* Load `pg_hint_plan` by adding `PG_HINT_PLAN` to `shared_preload_libraries`
   parameter in the Server Parameters page
 * Save and Restart to save and apply changes the change
 * Run `CREATE EXTENSION pg_hint_plan;`

--- a/workbooks/enabling_pg_hint_plan.mdx
+++ b/workbooks/enabling_pg_hint_plan.mdx
@@ -24,9 +24,10 @@ Below is an example of installing `pg_hint_plan` from a binary package:
 
 <CodeBlock language="bash">
 {`# For Debian or Ubuntu
-sudo apt install postgresql-<postgres version>-pg-hint-plan
-
-# For RHEL-based systems (assuming the PostgreSQL Yum repository is already enabled)
+sudo apt install postgresql-<postgres version>-pg-hint-plan`}
+</CodeBlock>
+<CodeBlock language="bash">
+{`# For RHEL-based systems (assuming the PostgreSQL Yum repository is already enabled)
 sudo dnf install pg_hint_plan_<postgres version>`}
 </CodeBlock>
 

--- a/workbooks/toc.yml
+++ b/workbooks/toc.yml
@@ -10,3 +10,5 @@
     href: workbooks/collector-workflow
   - name: Security & Privacy Considerations
     href: workbooks/security-privacy
+  - name: Enabling pg_hint_plan
+    href: workbooks/enabling_pg_hint_plan


### PR DESCRIPTION
Putting under Query Tuning section for now, but not linking from anything at the moment. There are several places in the existing doc that could potentially link from.

Part of https://github.com/pganalyze/pganalyze/issues/5068