### PR TITLE
Various updates from recent support requests

### DIFF
--- a/enterprise/troubleshooting.mdx
+++ b/enterprise/troubleshooting.mdx
@@ -72,7 +72,8 @@ When using IAM authentication on AWS (e.g. with an instance role), you may see a
 ... |         ...`}
 </CodeBlock>
 
-One common cause of this problem can be the HTTP response limit set on the IMDSv2 metadata endpoint, since the container that pganalyze Enterprise Server runs in counts as an extra hop on the network layer.
+One common cause of this problem can be the HTTP response limit set on the IMDSv2 metadata endpoint, since the container that pganalyze Enterprise Server runs 
+in counts as an extra hop on the network layer.
 
 Typically you can fix this error by raising the IMDSv2 hop limit to `2`, like this:
 
@@ -83,5 +84,14 @@ Typically you can fix this error by raising the IMDSv2 hop limit to `2`, like th
     --http-endpoint enabled \
     --http-put-response-hop-limit 2`}
 </CodeBlock>
+
+### Error: "NoCredentialProviders: no valid providers in chain. Deprecated.""
+
+When accessing logs for Amazon RDS or Aurora databases with IAM authentication, you may receive an error like this in the logs or when running a pganalyze-collector 
+test or self-check. This error, like the one above, usually indicates that the pganalyze container is unable to access the AWS metadata service to retrieve credentials 
+and needs at least one additional hop configured. In some cases, a hop limit of `3` may be required, depending on your network setup.
+
+Update the `http-put-response-hop-limit` to `2` as shown above.
+
 
 If this does not resolve the error, please [reach out to us](/contact).

--- a/install/amazon_rds/01_configure_rds_instance.mdx
+++ b/install/amazon_rds/01_configure_rds_instance.mdx
@@ -44,6 +44,12 @@ that can be helpful, e.g. to debug I/O issues.
 If Enhanced Monitoring is enabled, pganalyze will automatically collect and show
 this additional information in the dashboard as well.
 
+## Enable aurora_compute_plan_id for Amazon Aurora 
+If you are using Amazon Aurora versions 14.10, 15.5, or later, you can enable the `aurora_compute_plan_id` parameter in your RDS parameter group to get
+more detailed plan statistic information [(reference article)](https://pganalyze.com/blog/introducing-postgres-plan-statistics-for-amazon-aurora). The 
+pganalyze-collector will automatically collect this information and send it to pganalyze if this Amazon Aurora parameter is enabled.
+
+
 ---
 
 <Link className="btn btn-success" to="02_create_monitoring_user">

--- a/workbooks/collector-workflow.mdx
+++ b/workbooks/collector-workflow.mdx
@@ -75,7 +75,29 @@ To complete the setup, reset the role, and revoke the creation privilege again:
 {`RESET ROLE;
 REVOKE CREATE ON SCHEMA pganalyze FROM pganalyze_explain;`}
 </CodeBlock>
+<br/>
 
+## Resolving search_path issues
+The explain_analyze function is created with `SECURITY DEFINER`, which means it will run with the privileges of the `pganalyze_explain` role,
+but using the `search_path` of the role that calls it. This will be the role that the pganalyze-collector uses to connect to the database. If
+this role has a different `search_path` than the role(s) that are running queries, the function may return `object not found` errors when trying to
+run a query variant using the collector workflow.
+
+There are two ways to resolve this:
+ 1. Set the search_path of the pganalyze role to include all necessary schemas in the proper order. Replace `app_schema1,app_schema2` with the actual schema names you need.
+
+<CodeBlock language="sql">
+{`ALTER ROLE pganalyze SET search_path = app_schema1,app_schema2,public;`}
+</CodeBlock>
+
+ 2. Set the `search_path` on the function when you have SECURITY DEFINER set. This ensures that the function always uses the correct schemas regardless of who calls the function. 
+
+<CodeBlock language="sql">
+{`ALTER FUNCTION pganalyze.explain_analyze() SET search_path = master, extensions, public;`}
+</CodeBlock>
+<br/>
+
+ 
 ## Revoking access for dblink & other problematic functions
 
 Certain functions in Postgres can be problematic if permitted to be called. It is your

--- a/workbooks/collector-workflow.mdx
+++ b/workbooks/collector-workflow.mdx
@@ -78,19 +78,13 @@ REVOKE CREATE ON SCHEMA pganalyze FROM pganalyze_explain;`}
 <br/>
 
 ## Resolving search_path issues
-The explain_analyze function is created with `SECURITY DEFINER`, which means it will run with the privileges of the `pganalyze_explain` role,
+The `explain_analyze` function is created with `SECURITY DEFINER`, which means it will run with the privileges of the `pganalyze_explain` role,
 but using the `search_path` of the role that calls it. This will be the role that the pganalyze-collector uses to connect to the database. If
 this role has a different `search_path` than the role(s) that are running queries, the function may return `object not found` errors when trying to
 run a query variant using the collector workflow.
 
-There are two ways to resolve this:
- 1. Set the search_path of the pganalyze role to include all necessary schemas in the proper order. Replace `app_schema1,app_schema2` with the actual schema names you need.
-
-<CodeBlock language="sql">
-{`ALTER ROLE pganalyze SET search_path = app_schema1,app_schema2,public;`}
-</CodeBlock>
-
- 2. Set the `search_path` on the function when you have SECURITY DEFINER set. This ensures that the function always uses the correct schemas regardless of who calls the function. 
+To resolve the `search_path` issues, set the `search_path` on the function to ensure that it always uses the correct schemas regardless of what role
+calls the function. 
 
 <CodeBlock language="sql">
 {`ALTER FUNCTION pganalyze.explain_analyze() SET search_path = master, extensions, public;`}


### PR DESCRIPTION
- Enterprise setup instructions on AWS for IAM authentication reference `--http-put-response-hop-limit` but only for one specific error message. Adding another potential error for easier resolution.
- Collector workflow doesn't account for the function being run with the `search_path` of the collector database role (typically `pganalyze`). Providing alternative solutions for setting the `search_path` correctly.
- The collector automatically takes `aurora_stat_plan` into account if `aurora_compute_plan_id` is set to on (defaults to off). Referencing in docs for easier setup.