### PR TITLE
Rename query tuning advisor check name

### DIFF
--- a/checks/toc.yml
+++ b/checks/toc.yml
@@ -23,6 +23,8 @@
   items:
   - name: New Slow Queries
     href: checks/queries/slowness
+  - name: Advisor Insight
+    href: checks/queries/advisor_insight
 - mount: checks/connections
   items:
   - name: Active Queries

--- a/directory.json
+++ b/directory.json
@@ -308,6 +308,10 @@
       "title": "2025.03.3 Release",
       "path": "/docs/enterprise/releases/2025-03-3"
     },
+    "enterprise/releases/2025-03-4": {
+      "title": "2025.03.4 Release",
+      "path": "/docs/enterprise/releases/2025-03-4"
+    },
     "enterprise/settings": {
       "title": "Enterprise Server: Container settings",
       "path": "/docs/enterprise/settings"
@@ -2495,14 +2499,8 @@
     "disk sort": {
       "path": "/docs/explain/insights/disk-sort"
     },
-    "expensive": {
-      "path": "/docs/explain/insights/expensive"
-    },
     "hash batches": {
       "path": "/docs/explain/insights/hash-batches"
-    },
-    "i/o-heavy": {
-      "path": "/docs/explain/insights/io-heavy"
     },
     "inefficient index": {
       "path": "/docs/explain/insights/inefficient-index"

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -1,9 +1,7 @@
 export const CHECK_TITLES = {
   queries: {
     slowness: "New Slow Queries",
-  },
-  query_tuning: {
-    automated_explain: "Query Performance: Advisor Insights",
+    advisor_insight: "Advisor Insights",
   },
   connections: {
     active_query: "Active Queries",
@@ -106,6 +104,7 @@ export const CHECK_FREQUENCY_DAILY = "Daily";
 export const CHECK_FREQUENCY = {
   queries: {
     slowness: CHECK_FREQUENCY_DAILY,
+    advisor_insight: CHECK_FREQUENCY_DAILY,
   },
   connections: {
     active_query: CHECK_FREQUENCY_REALTIME,
@@ -114,9 +113,6 @@ export const CHECK_FREQUENCY = {
   },
   index_advisor: {
     indexing_engine: CHECK_FREQUENCY_DAILY,
-  },
-  query_tuning: {
-    automated_explain: CHECK_FREQUENCY_DAILY,
   },
   schema: {
     index_invalid: CHECK_FREQUENCY_30MIN,
@@ -160,6 +156,9 @@ export const DEFAULT_CHECK_CONFIGS: DefaultCheckConfigs = {
         minimum_calls: 50
       }
     },
+    advisor_insight: {
+      enabled: true
+    }
   },
   connections: {
     active_query: {


### PR DESCRIPTION
In passing:

* specify the default config value of queries/advisor_insight check (currently causing the web build failure)
* add a check to TOC
* regen directory.json