### PR TITLE
Documentation to enable PostGIS with the Enterprise container image

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -128,6 +128,10 @@
       "title": "Enterprise Edition: Log Insights Setup",
       "path": "/docs/enterprise/log-insights"
     },
+    "enterprise/postgis": {
+      "title": "Enterprise Server: Integrating PostGIS with pganalyze",
+      "path": "/docs/enterprise/postgis"
+    },
     "enterprise/releases": {
       "title": "Enterprise Server: Release Changelog",
       "path": "/docs/enterprise/releases"

--- a/enterprise/postgis.mdx
+++ b/enterprise/postgis.mdx
@@ -1,0 +1,32 @@
+---
+title: 'Enterprise Server: Integrating PostGIS with pganalyze'
+backlink_href: /docs/enterprise
+backlink_title: 'pganalyze Enterprise Server'
+---
+
+PostGIS is a powerful spatial database extention for PostgreSQL, allowing you to store and query geographic objects. 
+If you are using PostGIS with your PostgreSQL database, pganalyze can analyze queries with PostGIS specific datatypes and 
+functions as long as it is installed in the pganalyze Enterprise Server image.
+
+For licensing reasons, PostGIS is not included in the pganalyze Enterprise Server image that we provide to Enterprise users.
+However, users can create their own custom container image based on the official pganalyze Enterprise Server imagem and 
+install PostGIS in that image using the sample Dockerfile below.
+
+Replace `quay.io/pganalyze/enterprise:v2005.03.4` with the version of the pganalyze Enterprise Server image you are using.
+
+**Note:** You must be using a version of pganalyze Enterprise Server that is at least v2005.03.4 to integrate PostGIS with
+your own custom image.
+
+<CodeBlock>
+{`FROM quay.io/pganalyze/enterprise:v2005.03.3
+ 
+RUN apt-get update && apt-get install wget -y
+ 
+RUN mkdir vendor/postgis_mock
+RUN wget https://raw.githubusercontent.com/pganalyze/postgis_mock/refs/heads/main/postgis_mock.sql -O /home/app/vendor/postgis_mock/postgis_mock.sql
+ 
+WORKDIR /home/app/
+ENTRYPOINT ["/docker-entrypoint.enterprise.sh"]
+CMD ["/sbin/my_init"]
+EXPOSE 5000`}
+</CodeBlock>

--- a/enterprise/toc.yml
+++ b/enterprise/toc.yml
@@ -12,5 +12,7 @@
     href: enterprise/upgrade
   - name: Reference architecture
     href: enterprise/architecture
+  - name: Integrating PostGIS
+    href: enterprise/postgis
   - name: Troubleshooting
     href: enterprise/troubleshooting

--- a/workbooks/collector-workflow.mdx
+++ b/workbooks/collector-workflow.mdx
@@ -84,10 +84,11 @@ this role has a different `search_path` than the role(s) that are running querie
 run a query variant using the collector workflow.
 
 To resolve the `search_path` issues, set the `search_path` on the function to ensure that it always uses the correct schemas regardless of what role
-calls the function. 
+calls the function. Run the following `ALTER` command, ensuring that you replace `my_app_schema` with the schema(s) that contains your application 
+tables and functions.
 
 <CodeBlock language="sql">
-{`ALTER FUNCTION pganalyze.explain_analyze() SET search_path = master, extensions, public;`}
+{`ALTER FUNCTION pganalyze.explain_analyze(text, text[], text[], text[]) SET search_path = my_app_schema, public;`}
 </CodeBlock>
 <br/>
 


### PR DESCRIPTION
PostGIS is not included in the Enterprise Server container image for licensing reasons. Starting with release `2025.03.4`, users can now create their own custom images which include PostGIS.

I also fixed an error for ALTER'ing the Collector Workflow function published earlier.