### PR TITLE
Add the section of finding xmin with Aurora

### DIFF
--- a/components/CheckDocumentation/vacuum/XminHorizon.tsx
+++ b/components/CheckDocumentation/vacuum/XminHorizon.tsx
@@ -320,6 +320,17 @@ const GuidanceByStandby: React.FunctionComponent<{
         />
       </CodeBlock>
       <p>
+        If you're using Aurora, also use the following command to find the
+        <code>xmin</code> of readers:
+      </p>
+      <CodeBlock>
+        <SQL
+          sql={`SELECT server_id, session_id, feedback_xmin::text::xid as backend_xmin
+                  FROM aurora_replica_status()
+                  ORDER BY age(feedback_xmin::text::xid) DESC;`}
+        />
+      </CodeBlock>
+      <p>
         Once the standby is identified, you can find the query holding back the
         xmin horizon and its connection's pid in that standby by running the
         following command:


### PR DESCRIPTION
Find the definition of `aurora_replica_status()` here:

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora_replica_status.html

We're using the following for checking xmin for standbys currently, and the part in question is about `standby` part:

https://github.com/pganalyze/collector/blob/bd89a1e6898a10d4bd767b9909563e1a2c104e9c/input/postgres/server_stats.go#L25

Here is an example result. This includes the master/writer one, but I think it's okay to not add more conditions there as it's pretty obvious what it is.

```
postgres=> SELECT server_id, session_id, feedback_xmin::text::xid as backend_xmin
                  FROM aurora_replica_status()
                  ORDER BY age(feedback_xmin::text::xid) DESC;
               server_id               |              session_id              | backend_xmin 
---------------------------------------+--------------------------------------+--------------
 aws-aurora-test-instance-1-us-east-1b | MASTER_SESSION_ID                    |             
 aws-aurora-test-instance-1            | e4c4105a-478b-some-uuid-of-reader    |    824303745
(2 rows)
```