### PR TITLE
Remove aurora_stat_plans recommendation

### DIFF
--- a/install/amazon_rds/01_configure_rds_instance.mdx
+++ b/install/amazon_rds/01_configure_rds_instance.mdx
@@ -44,11 +44,6 @@ that can be helpful, e.g. to debug I/O issues.
 If Enhanced Monitoring is enabled, pganalyze will automatically collect and show
 this additional information in the dashboard as well.
 
-## Enable aurora_compute_plan_id for Amazon Aurora 
-If you are using Amazon Aurora versions 14.10, 15.5, or later, you can enable the `aurora_compute_plan_id` parameter in your RDS parameter group to get
-more detailed plan statistic information [(reference article)](https://pganalyze.com/blog/introducing-postgres-plan-statistics-for-amazon-aurora). The 
-pganalyze-collector will automatically collect this information and send it to pganalyze if this Amazon Aurora parameter is enabled.
-
 
 ---
 


### PR DESCRIPTION
A customer reported that despite increasing `pg_stat_statements.max` to 50,000, deallocations occurred around every 30 minutes, causing significant `LWLock:pg_stat_statements` lock contention. They were able to resolve the issue by setting `aurora_compute_plan_id = 0`, which disables aurora_stat_plans.

Until we have a better understanding of the issue, this PR removes the recommendation to enable aurora_stat_plans during collector setup.