### PR TITLE
Give more context to Check trigger docs

### DIFF
--- a/components/CheckDocumentation/index.tsx
+++ b/components/CheckDocumentation/index.tsx
@@ -80,12 +80,12 @@ type CheckProps = {
 
 export const CheckTrigger: React.FunctionComponent<
   CheckProps & CheckTriggerProps
-> = ({ checkGroup, checkName, config }) => {
+> = ({ checkGroup, checkName, config, source }) => {
   const TriggerComponent = Docs[checkGroup]?.[checkName]?.Trigger;
   if (!TriggerComponent) {
     return null;
   }
-  return <TriggerComponent config={config} />;
+  return <TriggerComponent config={config} source={source} />;
 };
 
 export const CheckGuidance: React.FunctionComponent<

--- a/util/checks/index.ts
+++ b/util/checks/index.ts
@@ -316,8 +316,16 @@ export type CheckConfig = {
   settings: { [key: string]: string | number | boolean };
 };
 
+// Where the config passed to a trigger component came from. The app renders a
+// server's actual check config ("app"), so trigger docs can describe concretely
+// what that check will and will not do. The public docs site has no server
+// context and renders DEFAULT_CHECK_CONFIGS instead ("defaults"), so
+// settings-specific wording would be misleading there.
+export type CheckConfigSource = "app" | "defaults";
+
 export type CheckTriggerProps = {
   config: CheckConfig;
+  source: CheckConfigSource;
 };
 
 // Consumers supply the subset of URLs that make sense in their context: the app


### PR DESCRIPTION
This allows rendering documentation specific to the server's actual
config in the app and more general config based on the defaults in the
public docs.
